### PR TITLE
Add redirect from /c2c to /c2c/

### DIFF
--- a/acceptance_tests/fastapi_app/fastapi_app/main.py
+++ b/acceptance_tests/fastapi_app/fastapi_app/main.py
@@ -6,11 +6,12 @@ from contextlib import asynccontextmanager
 import c2casgiutils
 import sentry_sdk
 from c2casgiutils import config, headers, health_checks
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
+from fastapi.responses import RedirectResponse
 from prometheus_client import start_http_server
 from prometheus_fastapi_instrumentator import Instrumentator
 from pydantic import BaseModel
@@ -94,6 +95,16 @@ async def root() -> RootResponse:
     Return a hello message.
     """
     return RootResponse(message="Hello World")
+
+
+@app.get("/c2c")
+async def redirect_c2c(request: Request) -> RedirectResponse:
+    """Redirect to the mounted `c2c` app canonical path."""
+    url = request.url
+    redirect_url = url.path + "/"
+    if url.query:
+        redirect_url += f"?{url.query}"
+    return RedirectResponse(url=redirect_url, status_code=307)
 
 
 # Add Routers

--- a/scaffold/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/main.py
+++ b/scaffold/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/main.py
@@ -6,11 +6,12 @@ from contextlib import asynccontextmanager
 import c2casgiutils
 import sentry_sdk
 from c2casgiutils import config, headers, health_checks
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
+from fastapi.responses import RedirectResponse
 from prometheus_client import start_http_server
 from prometheus_fastapi_instrumentator import Instrumentator
 from pydantic import BaseModel
@@ -96,6 +97,15 @@ async def root() -> RootResponse:
     """
     return RootResponse(message="Hello World")
 
+
+@app.get("/c2c")
+async def redirect_c2c(request: Request) -> RedirectResponse:
+    """Redirect to the mounted `c2c` app canonical path."""
+    url = request.url
+    redirect_url = url.path + "/"
+    if url.query:
+        redirect_url += f"?{url.query}"
+    return RedirectResponse(url=redirect_url, status_code=307)
 
 # Add Routers
 app.mount("/api", api.app)


### PR DESCRIPTION
- [x] Update `/c2c` redirect to build URL from `request.url`, preserving query parameters and `root_path`/URL prefix
- [x] Add `Request` to FastAPI imports in both scaffold and acceptance test app

<!-- START COPILOT CODING AGENT TIPS -->
---

⚡ Quickly spin up Copilot coding agent tasks from anywhere on your macOS or Windows machine with [Raycast](https://gh.io/cca-raycast-docs).
