### PR TITLE
Remove redirect http to https middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,6 @@ app.add_middleware(
     allowed_hosts=["*"],  # Configure with specific hosts in production
 )
 
-# Add HTTPSRedirectMiddleware
-if config.settings.http:
-    app.add_middleware(HTTPSRedirectMiddleware)
-
 # Add GZipMiddleware
 app.add_middleware(GZipMiddleware, minimum_size=1000)
 

--- a/acceptance_tests/fastapi_app/fastapi_app/main.py
+++ b/acceptance_tests/fastapi_app/fastapi_app/main.py
@@ -9,7 +9,6 @@ from c2casgiutils import config, headers, health_checks
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
-from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.responses import RedirectResponse
 from prometheus_client import start_http_server
@@ -55,10 +54,6 @@ app.add_middleware(
     TrustedHostMiddleware,
     allowed_hosts=["*"],  # Configure with specific hosts in production
 )
-
-# Add HTTPSRedirectMiddleware
-if not config.settings.http:
-    app.add_middleware(HTTPSRedirectMiddleware)
 
 # Add GZipMiddleware
 app.add_middleware(GZipMiddleware, minimum_size=1000)

--- a/scaffold/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/main.py
+++ b/scaffold/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/main.py
@@ -9,7 +9,6 @@ from c2casgiutils import config, headers, health_checks
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
-from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.responses import RedirectResponse
 from prometheus_client import start_http_server
@@ -56,10 +55,6 @@ app.add_middleware(
     TrustedHostMiddleware,
     allowed_hosts=["*"],  # Configure with specific hosts in production
 )
-
-# Add HTTPSRedirectMiddleware
-if not config.settings.http:
-    app.add_middleware(HTTPSRedirectMiddleware)
 
 # Add GZipMiddleware
 app.add_middleware(GZipMiddleware, minimum_size=1000)


### PR DESCRIPTION
* Not working in environment like Kubernetes for the checkers
* Generally not the job of the application but of the reverse proxy 
* See also: https://github.com/camptocamp/c2casgiutils/pull/159