### PR TITLE
Remove header Expect-CT in default config, it is deprecated

### DIFF
--- a/c2casgiutils/headers.py
+++ b/c2casgiutils/headers.py
@@ -90,7 +90,6 @@ DEFAULT_HEADERS_CONFIG: dict[str, HeaderMatcher] = {
             "Referrer-Policy": "no-referrer",
             "Permissions-Policy": ["geolocation=()", "microphone=()"],
             "X-DNS-Prefetch-Control": "off",
-            "Expect-CT": "max-age=86400, enforce",
             "Origin-Agent-Cluster": "?1",
             "Cross-Origin-Embedder-Policy": "require-corp",
             "Cross-Origin-Opener-Policy": "same-origin",


### PR DESCRIPTION
See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Expect-CT#browser_compatibility