### PR TITLE
Add configurable proxy header middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,49 @@
 # Changelog
 
+## 0.9
+
+### Added
+
+- **Headers**: Added `ForwardedHeadersMiddleware` to rewrite request host/scheme/port from trusted proxy headers for correct absolute URL generation.
+- **Settings**: Added proxy headers settings:
+  - `C2C__PROXY_HEADERS__TYPE` with values `none` (default), `x-forwarded`, `forwarded`
+  - `C2C__PROXY_HEADERS__TRUSTED_HOSTS` as a comma-separated list of trusted proxy clients/networks
+
+### Changed
+
+- **Scaffold**: The generated FastAPI application now conditionally enables `ForwardedHeadersMiddleware` from `config.settings.proxy_headers`.
+- **Acceptance app**: The acceptance application now conditionally enables `ForwardedHeadersMiddleware` from `config.settings.proxy_headers`.
+
+### Migration Guide
+
+If you want to enable proxy host/proto/port rewriting in your project, add this code in your `main.py` (after your existing middleware setup):
+
+```python
+app.add_middleware(
+    headers.ArmorHeaderMiddleware,
+    headers_config={"http": {"headers": {"Strict-Transport-Security": None}}}
+    if config.settings.http
+    else {},
+)
+
+if config.settings.proxy_headers.type != "none":
+    app.add_middleware(
+        headers.ForwardedHeadersMiddleware,
+        trusted_hosts=config.settings.proxy_headers.trusted_hosts,
+        headers_type=config.settings.proxy_headers.type,
+    )
+```
+
+Then configure your environment, for example:
+
+```bash
+export C2C__PROXY_HEADERS__TYPE=x-forwarded
+export C2C__PROXY_HEADERS__TRUSTED_HOSTS=127.0.0.1,10.0.0.0/8
+```
+
 ## 0.7
 
-### ⚠️ Breaking Changes & Migration Guide
+### Breaking Changes & Migration Guide
 
 #### Application
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,13 @@ The scaffold Dockerfile uses `uvicorn` to start the application. Typical flags i
 - `--port=8080` to expose the HTTP port.
 - `--log-config=/app/logging.yaml` to load the logging configuration.
 
-When the app runs behind a reverse proxy (Kubernetes Ingress, Traefik, nginx, etc.), enable forwarded headers so the
-app keeps the correct scheme (`https`) and client IP:
+See the Uvicorn settings reference for the full list of options: https://www.uvicorn.org/settings/
+
+### Forwarded headers handling (Reverse proxy)
+
+When the app runs behind a reverse proxy (Kubernetes Ingress, Traefik, nginx, etc.) you should trust forwarded headers.
+
+If the `Host` header has the right values you can use the option provided by Uvicorn:
 
 ```bash
 --proxy-headers --forwarded-allow-ips=*
@@ -53,7 +58,20 @@ app keeps the correct scheme (`https`) and client IP:
 - `--forwarded-allow-ips=*` allows forwarded headers from any upstream proxy. If you know your proxy IPs, prefer a
   strict list instead of `*` to harden the configuration.
 
-See the Uvicorn settings reference for the full list of options: https://www.uvicorn.org/settings/
+If the `Host` header is not correct, for example with Apache and the default configuration,
+the header `X-Forwarded-Host` or `Forwarded` should also be interpreted.
+
+In that case, `ForwardedHeadersMiddleware` is required.
+
+To use the [RFC7239](https://www.rfc-editor.org/rfc/rfc7239) `Forwarded` header, set `C2C__PROXY_HEADERS__TYPE=forwarded`.
+Or use `C2C__PROXY_HEADERS__TYPE=x-forwarded` to trust `X-Forwarded-*`.
+
+Use `C2C__PROXY_HEADERS__TRUSTED_HOSTS=...` to restrict which proxy IPs are trusted (use `*` only if you must).
+
+Note: when `--proxy-headers` is enabled, Uvicorn updates the client address before
+`ForwardedHeadersMiddleware` runs. That means `trusted_hosts` is matched against the updated
+client address, not the direct peer connection. If you want this middleware to validate the
+direct proxy IP, run Uvicorn without `--proxy-headers` and rely on the middleware instead.
 
 ## Installation
 
@@ -109,6 +127,14 @@ app.add_middleware(headers.ArmorHeaderMiddleware,
         "http": {"headers": {"Strict-Transport-Security": None} if not config.settings.http else {}},
     }
 )
+
+# Optional: trust host/port from forwarded proxy headers
+if config.settings.proxy_headers.type != "none":
+    app.add_middleware(
+        headers.ForwardedHeadersMiddleware,
+        trusted_hosts=config.settings.proxy_headers.trusted_hosts,
+        headers_type=config.settings.proxy_headers.type,
+    )
 
 # Get Prometheus HTTP server port from environment variable 9000 by default
 start_http_server(config.settings.prometheus.port)
@@ -885,6 +911,22 @@ Redis prefix for logging settings
 _Optional_, default value: `c2casgiutils`
 
 Application module name for logging
+
+### `C2C__PROXY_HEADERS__TYPE`
+
+_Optional_, default value: `none`
+
+Proxy headers mode: 'none' disables host/proto rewriting, 'x-forwarded' trusts X-Forwarded-\* headers, 'forwarded' trusts RFC7239 Forwarded header
+
+#### Possible values
+
+`none`, `x-forwarded`, `forwarded`
+
+### `C2C__PROXY_HEADERS__TRUSTED_HOSTS`
+
+_Optional_, default value: `['127.0.0.1']`
+
+Trusted proxy client hosts/networks. Accepts comma-separated string or list (e.g. '127.0.0.1,10.0.0.0/8' or '\*').
 
 ### `C2C__HTTP`
 

--- a/acceptance_tests/fastapi_app/fastapi_app/main.py
+++ b/acceptance_tests/fastapi_app/fastapi_app/main.py
@@ -72,6 +72,13 @@ app.add_middleware(
     headers_config={"http": {"headers": {"Strict-Transport-Security": None}}} if config.settings.http else {},
 )
 
+if config.settings.proxy_headers.type != "none":
+    app.add_middleware(
+        headers.ForwardedHeadersMiddleware,
+        trusted_hosts=config.settings.proxy_headers.trusted_hosts,
+        headers_type=config.settings.proxy_headers.type,
+    )
+
 
 class RootResponse(BaseModel):
     """Response of the root endpoint."""

--- a/c2casgiutils/config.py
+++ b/c2casgiutils/config.py
@@ -264,6 +264,39 @@ class SettingsTools(BaseModel):
     ] = SettingsToolsLogging()
 
 
+class ProxyHeaders(BaseModel):
+    """Proxy headers handling settings."""
+
+    type: Annotated[
+        Literal["none", "x-forwarded", "forwarded"],
+        Field(
+            description=(
+                "Proxy headers mode: 'none' disables host/proto rewriting, "
+                "'x-forwarded' trusts X-Forwarded-* headers, 'forwarded' trusts RFC7239 Forwarded header"
+            ),
+        ),
+    ] = "none"
+    trusted_hosts: Annotated[
+        list[str] | str,
+        Field(
+            description=(
+                "Trusted proxy client hosts/networks. Accepts comma-separated string or list "
+                "(e.g. '127.0.0.1,10.0.0.0/8' or '*')."
+            ),
+        ),
+    ] = ["127.0.0.1"]
+
+    @field_validator("trusted_hosts", mode="before")
+    @classmethod
+    def normalize_trusted_hosts(cls, value: list[str] | str | None) -> list[str]:
+        """Normalize trusted_hosts from env values to a list."""
+        if value is None:
+            return ["127.0.0.1"]
+        if isinstance(value, list):
+            return [v.strip() for v in value if v.strip()]
+        return [v.strip() for v in value.split(",") if v.strip()]
+
+
 class Settings(BaseSettings, extra="ignore"):
     """Application settings."""
 
@@ -293,6 +326,10 @@ class Settings(BaseSettings, extra="ignore"):
         SettingsTools,
         Field(description="Tools settings"),
     ] = SettingsTools()
+    proxy_headers: Annotated[
+        ProxyHeaders,
+        Field(description="Proxy headers handling settings"),
+    ] = ProxyHeaders()
     http: Annotated[
         bool,
         Field(

--- a/c2casgiutils/headers.py
+++ b/c2casgiutils/headers.py
@@ -1,15 +1,18 @@
 import base64
+import ipaddress
 import logging
 import re
 import secrets
 from collections.abc import Awaitable, Callable, Collection
-from typing import TypedDict
+from typing import Literal, TypedDict
+from urllib.parse import urlsplit
 
 from pydantic import BaseModel
+from starlette.datastructures import MutableHeaders
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
-from starlette.types import ASGIApp
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -20,6 +23,201 @@ Header = str | list[str] | dict[str, str] | dict[str, list[str]] | None
 
 # Placeholder that will be replaced with a generated nonce random value.
 CSP_NONCE = "'nonce'"
+
+_ALLOWED_PROTO = {"http", "https", "ws", "wss"}
+_DEFAULT_PORT_BY_SCHEME = {"http": 80, "https": 443, "ws": 80, "wss": 443}
+
+
+def _parse_raw_hosts(value: str) -> list[str]:
+    return [item for item in (part.strip() for part in value.split(",")) if item]
+
+
+class _TrustedHosts:
+    """Container for trusted hosts and networks."""
+
+    def __init__(self, trusted_hosts: list[str] | str) -> None:
+        self.always_trust: bool = trusted_hosts in ("*", ["*"])
+
+        self.trusted_literals: set[str] = set()
+        self.trusted_hosts: set[ipaddress.IPv4Address | ipaddress.IPv6Address] = set()
+        self.trusted_networks: set[ipaddress.IPv4Network | ipaddress.IPv6Network] = set()
+
+        if not self.always_trust:
+            if isinstance(trusted_hosts, str):
+                trusted_hosts = _parse_raw_hosts(trusted_hosts)
+
+            for host in trusted_hosts:
+                if "/" in host:
+                    try:
+                        self.trusted_networks.add(ipaddress.ip_network(host))
+                    except ValueError:
+                        self.trusted_literals.add(host)
+                else:
+                    try:
+                        self.trusted_hosts.add(ipaddress.ip_address(host))
+                    except ValueError:
+                        self.trusted_literals.add(host)
+
+    def __contains__(self, host: str | None) -> bool:
+        """Check if a client host is trusted."""
+        if self.always_trust:
+            return True
+
+        if not host:
+            return False
+
+        try:
+            ip = ipaddress.ip_address(host)
+            if ip in self.trusted_hosts:
+                return True
+            return any(ip in net for net in self.trusted_networks)
+
+        except ValueError:
+            return host in self.trusted_literals
+
+
+def _first_csv_header_value(value: str | None) -> str | None:
+    if value is None:
+        return None
+    first_value = value.split(",", 1)[0].strip()
+    return first_value or None
+
+
+def _unquote_header_value(value: str) -> str:
+    stripped = value.strip()
+    if len(stripped) >= 2 and stripped[0] == stripped[-1] == '"':
+        return stripped[1:-1]
+    return stripped
+
+
+def _parse_forwarded_header(value: str | None) -> dict[str, str]:
+    if value is None:
+        return {}
+    first_item = _first_csv_header_value(value)
+    if first_item is None:
+        return {}
+
+    result: dict[str, str] = {}
+    for part in first_item.split(";"):
+        key, separator, raw_val = part.partition("=")
+        if not separator:
+            continue
+        normalized_key = key.strip().lower()
+        normalized_value = _unquote_header_value(raw_val)
+        if normalized_key and normalized_value:
+            result[normalized_key] = normalized_value
+    return result
+
+
+def _split_host_port(host_value: str) -> tuple[str | None, int | None]:
+    try:
+        parsed = urlsplit(f"//{host_value}")
+    except ValueError:
+        return None, None
+    else:
+        return parsed.hostname, parsed.port
+
+
+def _format_host_header(host: str, port: int | None, scheme: str) -> str:
+    host_header = f"[{host}]" if ":" in host and not host.startswith("[") else host
+    default_port = _DEFAULT_PORT_BY_SCHEME.get(scheme)
+    if port is not None and port != default_port:
+        return f"{host_header}:{port}"
+    return host_header
+
+
+class ForwardedHeadersMiddleware:
+    """Apply trusted proxy host/proto/port headers to ASGI scope.
+
+    Uvicorn's proxy middleware updates scheme and client address but does not rewrite
+    the host used by Starlette/FastAPI absolute URL generation. This middleware updates
+    `scope["scheme"]`, `scope["server"]`, and `Host` from trusted `Forwarded` or
+    `X-Forwarded-*` headers.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        trusted_hosts: list[str] | str = "127.0.0.1",
+        headers_type: Literal["x-forwarded", "forwarded"] = "x-forwarded",
+    ) -> None:
+        self.app = app
+        self.trusted_hosts = _TrustedHosts(trusted_hosts)
+        self.headers_type = headers_type
+
+    async def __call__(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        """Apply trusted forwarded headers before calling the downstream app."""
+        if scope["type"] not in ("http", "websocket"):
+            await self.app(scope, receive, send)
+            return
+
+        if self.headers_type not in ("forwarded", "x-forwarded"):
+            if self.headers_type != "none":  # type: ignore[comparison-overlap]
+                _LOGGER.warning(
+                    "Invalid headers_type '%s' for ForwardedHeadersMiddleware; expected 'forwarded', 'x-forwarded', or 'none'. No headers will be processed.",
+                    self.headers_type,
+                )
+            await self.app(scope, receive, send)
+            return
+
+        client_addr = scope.get("client")
+        client_host = client_addr[0] if client_addr else None
+        if client_host not in self.trusted_hosts:
+            _LOGGER.debug(
+                "Client host '%s' not in trusted hosts; skipping forwarded header processing.",
+                client_host,
+            )
+            await self.app(scope, receive, send)
+            return
+
+        headers = MutableHeaders(scope=scope)
+
+        host: str | None = None
+        port: int | None = None
+        scheme = scope.get("scheme", "http")
+        forwarded_scheme: str | None = None
+        forwarded_host: str | None = None
+        x_forwarded_port: str | None = None
+
+        if self.headers_type == "forwarded":
+            forwarded = (
+                _parse_forwarded_header(headers.get("forwarded")) if self.headers_type == "forwarded" else {}
+            )
+            forwarded_scheme = forwarded.get("proto")
+            forwarded_host = forwarded.get("host")
+        else:
+            forwarded_scheme = _first_csv_header_value(headers.get("x-forwarded-proto"))
+            forwarded_host = _first_csv_header_value(headers.get("x-forwarded-host"))
+            x_forwarded_port = _first_csv_header_value(headers.get("x-forwarded-port"))
+
+        if forwarded_scheme:
+            forwarded_scheme = forwarded_scheme.lower()
+        if forwarded_scheme and forwarded_scheme in _ALLOWED_PROTO:
+            if scope["type"] == "websocket":
+                scope["scheme"] = forwarded_scheme.replace("http", "ws")
+            else:
+                scope["scheme"] = forwarded_scheme
+            scheme = scope["scheme"]
+
+        if forwarded_host:
+            host, port = _split_host_port(forwarded_host)
+
+        if port is None and x_forwarded_port and x_forwarded_port.isdigit():
+            port = int(x_forwarded_port)
+
+        if host is not None:
+            if port is None:
+                port = _DEFAULT_PORT_BY_SCHEME.get(scheme, 80)
+
+            scope["server"] = (host, port)
+            headers["host"] = _format_host_header(host, port, scheme)
+
+        await self.app(scope, receive, send)
 
 
 class HeaderMatcher(TypedDict, total=False):

--- a/scaffold/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/main.py
+++ b/scaffold/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/main.py
@@ -74,6 +74,13 @@ app.add_middleware(
     else {},
 )
 
+if config.settings.proxy_headers.type != "none":
+    app.add_middleware(
+        headers.ForwardedHeadersMiddleware,
+        trusted_hosts=config.settings.proxy_headers.trusted_hosts,
+        headers_type=config.settings.proxy_headers.type,
+    )
+
 
 class RootResponse(BaseModel):
     """Response of the root endpoint."""

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -98,3 +98,28 @@ def test_tags_with_empty_value(clean_env):
         "empty": "",
         "nonempty": "value",
     }
+
+
+def test_proxy_headers_defaults(clean_env):
+    settings = Settings()
+
+    assert settings.proxy_headers.type == "none"
+    assert settings.proxy_headers.trusted_hosts == ["127.0.0.1"]
+
+
+def test_proxy_headers_from_environment(clean_env):
+    os.environ["C2C__PROXY_HEADERS__TYPE"] = "x-forwarded"
+    os.environ["C2C__PROXY_HEADERS__TRUSTED_HOSTS"] = "127.0.0.1,10.0.0.0/8, 192.168.1.1"
+
+    settings = Settings()
+
+    assert settings.proxy_headers.type == "x-forwarded"
+    assert settings.proxy_headers.trusted_hosts == ["127.0.0.1", "10.0.0.0/8", "192.168.1.1"]
+
+
+def test_proxy_headers_forwarded_type(clean_env):
+    os.environ["C2C__PROXY_HEADERS__TYPE"] = "forwarded"
+
+    settings = Settings()
+
+    assert settings.proxy_headers.type == "forwarded"

--- a/test/test_header.py
+++ b/test/test_header.py
@@ -813,3 +813,254 @@ async def test_dispatch_nonce_base64_encoding(mock_request):
         valid_base64 = False
 
     assert valid_base64, "Nonce should be valid base64"
+
+
+@pytest.mark.asyncio
+async def test_forwarded_headers_middleware_x_forwarded_host_port_proto():
+    from c2casgiutils.headers import ForwardedHeadersMiddleware
+
+    captured_scope = None
+
+    async def simple_app(scope, receive, send):
+        nonlocal captured_scope
+        captured_scope = scope
+        response = Response("ok")
+        await response(scope, receive, send)
+
+    middleware = ForwardedHeadersMiddleware(simple_app, trusted_hosts="*", headers_type="x-forwarded")
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/tiles/admin/",
+        "raw_path": b"/tiles/admin/",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [
+            (b"host", b"wrong"),
+            (b"x-forwarded-host", b"geoservices-int.camptocamp.com"),
+            (b"x-forwarded-port", b"443"),
+            (b"x-forwarded-proto", b"https"),
+        ],
+        "client": ("127.0.0.1", 1234),
+        "server": ("127.0.0.1", 8080),
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(_message):
+        return None
+
+    await middleware(scope, receive, send)
+
+    assert captured_scope is not None
+    assert captured_scope["scheme"] == "https"
+    assert captured_scope["server"] == ("geoservices-int.camptocamp.com", 443)
+    headers = dict(captured_scope["headers"])
+    assert headers[b"host"] == b"geoservices-int.camptocamp.com"
+
+
+@pytest.mark.asyncio
+async def test_forwarded_headers_middleware_prefers_forwarded_header():
+    from c2casgiutils.headers import ForwardedHeadersMiddleware
+
+    captured_scope = None
+
+    async def simple_app(scope, receive, send):
+        nonlocal captured_scope
+        captured_scope = scope
+        response = Response("ok")
+        await response(scope, receive, send)
+
+    middleware = ForwardedHeadersMiddleware(simple_app, trusted_hosts="*", headers_type="forwarded")
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/tiles/admin/",
+        "raw_path": b"/tiles/admin/",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [
+            (b"host", b"wrong"),
+            (b"forwarded", b"for=5.1.102.69;host=forwarded.example.com:8443;proto=https"),
+            (b"x-forwarded-host", b"x-forwarded.example.com"),
+            (b"x-forwarded-port", b"443"),
+            (b"x-forwarded-proto", b"http"),
+        ],
+        "client": ("127.0.0.1", 1234),
+        "server": ("127.0.0.1", 8080),
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(_message):
+        return None
+
+    await middleware(scope, receive, send)
+
+    assert captured_scope is not None
+    assert captured_scope["scheme"] == "https"
+    assert captured_scope["server"] == ("forwarded.example.com", 8443)
+    headers = dict(captured_scope["headers"])
+    assert headers[b"host"] == b"forwarded.example.com:8443"
+
+
+@pytest.mark.asyncio
+async def test_forwarded_headers_middleware_skips_untrusted_client():
+    from c2casgiutils.headers import ForwardedHeadersMiddleware
+
+    captured_scope = None
+
+    async def simple_app(scope, receive, send):
+        nonlocal captured_scope
+        captured_scope = scope
+        response = Response("ok")
+        await response(scope, receive, send)
+
+    middleware = ForwardedHeadersMiddleware(
+        simple_app,
+        trusted_hosts=["10.0.0.1"],
+        headers_type="x-forwarded",
+    )
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/tiles/admin/",
+        "raw_path": b"/tiles/admin/",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [
+            (b"host", b"wrong"),
+            (b"x-forwarded-host", b"geoservices-int.camptocamp.com"),
+            (b"x-forwarded-port", b"443"),
+            (b"x-forwarded-proto", b"https"),
+        ],
+        "client": ("127.0.0.1", 1234),
+        "server": ("127.0.0.1", 8080),
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(_message):
+        return None
+
+    await middleware(scope, receive, send)
+
+    assert captured_scope is not None
+    assert captured_scope["scheme"] == "http"
+    assert captured_scope["server"] == ("127.0.0.1", 8080)
+    headers = dict(captured_scope["headers"])
+    assert headers[b"host"] == b"wrong"
+
+
+@pytest.mark.asyncio
+async def test_forwarded_headers_middleware_forwarded_mode_ignores_x_forwarded_headers():
+    from c2casgiutils.headers import ForwardedHeadersMiddleware
+
+    captured_scope = None
+
+    async def simple_app(scope, receive, send):
+        nonlocal captured_scope
+        captured_scope = scope
+        response = Response("ok")
+        await response(scope, receive, send)
+
+    middleware = ForwardedHeadersMiddleware(simple_app, trusted_hosts="*", headers_type="forwarded")
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/tiles/admin/",
+        "raw_path": b"/tiles/admin/",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [
+            (b"host", b"wrong"),
+            (b"x-forwarded-host", b"x-forwarded.example.com"),
+            (b"x-forwarded-port", b"443"),
+            (b"x-forwarded-proto", b"https"),
+        ],
+        "client": ("127.0.0.1", 1234),
+        "server": ("127.0.0.1", 8080),
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(_message):
+        return None
+
+    await middleware(scope, receive, send)
+
+    assert captured_scope is not None
+    assert captured_scope["scheme"] == "http"
+    assert captured_scope["server"] == ("127.0.0.1", 8080)
+    headers = dict(captured_scope["headers"])
+    assert headers[b"host"] == b"wrong"
+
+
+@pytest.mark.asyncio
+async def test_forwarded_headers_middleware_x_forwarded_mode_ignores_forwarded_header():
+    from c2casgiutils.headers import ForwardedHeadersMiddleware
+
+    captured_scope = None
+
+    async def simple_app(scope, receive, send):
+        nonlocal captured_scope
+        captured_scope = scope
+        response = Response("ok")
+        await response(scope, receive, send)
+
+    middleware = ForwardedHeadersMiddleware(simple_app, trusted_hosts="*", headers_type="x-forwarded")
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/tiles/admin/",
+        "raw_path": b"/tiles/admin/",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [
+            (b"host", b"wrong"),
+            (b"forwarded", b"for=5.1.102.69;host=forwarded.example.com;proto=https"),
+            (b"x-forwarded-host", b"x-forwarded.example.com"),
+            (b"x-forwarded-port", b"8443"),
+            (b"x-forwarded-proto", b"https"),
+        ],
+        "client": ("127.0.0.1", 1234),
+        "server": ("127.0.0.1", 8080),
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(_message):
+        return None
+
+    await middleware(scope, receive, send)
+
+    assert captured_scope is not None
+    assert captured_scope["scheme"] == "https"
+    assert captured_scope["server"] == ("x-forwarded.example.com", 8443)
+    headers = dict(captured_scope["headers"])
+    assert headers[b"host"] == b"x-forwarded.example.com:8443"


### PR DESCRIPTION
## Summary
- add a new `ForwardedHeadersMiddleware` that rewrites scheme/host/port from trusted proxy headers for correct absolute URL generation
- add configurable settings via `C2C__PROXY_HEADERS__TYPE` (`none`, `x-forwarded`, `forwarded`) and `C2C__PROXY_HEADERS__TRUSTED_HOSTS`
- wire the middleware in the acceptance app and scaffold template, update docs/changelog, and add coverage in config/header tests
