### PR TITLE
Handle expired GitHub OAuth sessions cleanly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - **Async I/O compliance**: Replaced `aiofiles` usage in CLI logging config loading with `anyio.Path`, and removed direct `aiofiles` dependency from project metadata.
+- **GitHub auth sessions**: GitHub OAuth sessions now attempt to refresh expired access tokens automatically. If refresh is unavailable or fails, the auth cookie is cleared so users are logged out instead of remaining logged-in without repository permissions.
+- **GitHub auth expiration**: Added a configurable token expiration safety margin with `C2C__AUTH__GITHUB__ACCESS_TOKEN_EXPIRATION_MARGIN` (ISO 8601 duration, default `PT1M`) and removed duplicate token-refresh checks inside `check_access_config`.
 
 ## [0.11.0] - 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **Async I/O compliance**: Replaced `aiofiles` usage in CLI logging config loading with `anyio.Path`, and removed direct `aiofiles` dependency from project metadata.
 - **GitHub auth sessions**: GitHub OAuth sessions now attempt to refresh expired access tokens automatically. If refresh is unavailable or fails, the auth cookie is cleared so users are logged out instead of remaining logged-in without repository permissions.
+- **Auth dependency ergonomics**: Added injectable `AccessContext` helpers with the methods `require_access`, `require_admin_access`, `check_access` and `check_admin_access` to simplify route protection code.
 - **GitHub auth expiration**: Added a configurable token expiration safety margin with `C2C__AUTH__GITHUB__ACCESS_TOKEN_EXPIRATION_MARGIN` (ISO 8601 duration, default `PT1M`) and removed duplicate token-refresh checks inside `check_access_config`.
 
 ## [0.11.0] - 2026-04-17

--- a/README.md
+++ b/README.md
@@ -893,6 +893,12 @@ GitHub state cookie name
 
 GitHub state cookie age in seconds (default: 10 minutes)
 
+### `C2C__AUTH__GITHUB__ACCESS_TOKEN_EXPIRATION_MARGIN`
+
+*Optional*, default value: `PT1M`
+
+Safety margin applied before checking GitHub access token expiration. Accepts ISO 8601 durations (e.g.: `PT1M` for 1 minute).
+
 ### `C2C__AUTH__TEST__USERNAME`
 
 *Optional*, default value: `None`

--- a/c2casgiutils/auth.py
+++ b/c2casgiutils/auth.py
@@ -10,7 +10,7 @@ import jwt
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, Query, Request, Response, status
 from fastapi.responses import RedirectResponse
 from fastapi.security import APIKeyHeader, APIKeyQuery
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from c2casgiutils.config import settings
 
@@ -59,6 +59,39 @@ class AuthInfo(BaseModel):
     is_logged_in: bool
     user: UserInfo
     session_payload: GitHubSessionPayload | None = Field(default=None, exclude=True)
+
+
+class AccessContext:
+    """Request-scoped authentication context for access checks."""
+
+    def __init__(self, auth_info: AuthInfo, request: Request, response: Response) -> None:
+        self.auth_info = auth_info
+        self.request = request
+        self.response = response
+
+    async def check_access(self, auth_config: AuthConfig) -> bool:
+        """Check whether the current user has access to the configured repository."""
+        return await check_access(self.auth_info, auth_config, request=self.request, response=self.response)
+
+    async def check_admin_access(self) -> bool:
+        """Check whether the current user has admin access."""
+        return await check_admin_access(self.auth_info, request=self.request, response=self.response)
+
+    async def require_access(self, auth_config: AuthConfig) -> None:
+        """Require access to the configured repository or raise HTTP 403."""
+        if not await self.check_access(auth_config):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You don't have access to this resource",
+            )
+
+    async def require_admin_access(self) -> None:
+        """Require admin access or raise HTTP 403."""
+        if not await self.check_admin_access():
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You don't have admin access to this resource",
+            )
 
 
 async def _is_auth_secret(
@@ -245,10 +278,18 @@ async def _is_auth_user_github(request: Request, response: Response) -> AuthInfo
         response.delete_cookie(key=settings.auth.jwt.cookie.name, path=_get_jwt_cookie_path(request))
         raise HTTPException(401, "Invalid session") from jwt_exception
 
+    session_payload: GitHubSessionPayload | None = None
+    if user_payload is not None:
+        try:
+            session_payload = GitHubSessionPayload.model_validate(user_payload)
+        except ValidationError as validation_exception:
+            response.delete_cookie(key=settings.auth.jwt.cookie.name, path=_get_jwt_cookie_path(request))
+            raise HTTPException(401, "Invalid session") from validation_exception
+
     auth_info = AuthInfo(
         is_logged_in=user_payload is not None,
         user=UserInfo(**(user_payload or {})),
-        session_payload=user_payload,
+        session_payload=session_payload,
     )
 
     if not auth_info.is_logged_in:
@@ -285,6 +326,23 @@ async def get_auth(request: Request, response: Response) -> AuthInfo:
         return await _is_auth_user_github(request, response)
 
     return AuthInfo(is_logged_in=False, user=UserInfo())
+
+
+async def get_access_context(
+    auth_info: Annotated[AuthInfo, Depends(get_auth)],
+    request: Request,
+    response: Response,
+) -> AccessContext:
+    """
+    Build an injectable access context for the current request.
+
+    Usage:
+        @app.get("/protected")
+        async def protected_route(access_context: Annotated[AccessContext, Depends(get_access_context)]):
+            await access_context.require_access(AuthConfig(github_repository="org/repo", github_access_type="admin"))
+            return {"message": "You have access"}
+    """
+    return AccessContext(auth_info, request, response)
 
 
 async def auth_required(auth_info: Annotated[AuthInfo, Depends(get_auth)]) -> None:
@@ -451,11 +509,8 @@ async def require_access(
             )
             return {"message": "You have access"}
     """
-    if not await check_access(auth_info, auth_config, request=request, response=response):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You don't have access to this resource",
-        )
+    access_context = AccessContext(auth_info, request, response)
+    await access_context.require_access(auth_config)
 
 
 async def require_admin_access(
@@ -470,11 +525,8 @@ async def require_admin_access(
         async def admin_protected_route(_: Annotated[bool, Depends(require_admin_access)]):
             return {"message": "You have admin access"}
     """
-    if not await check_admin_access(auth_info, request=request, response=response):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You don't have admin access to this resource",
-        )
+    access_context = AccessContext(auth_info, request, response)
+    await access_context.require_admin_access()
 
 
 def is_enabled() -> bool:

--- a/c2casgiutils/auth.py
+++ b/c2casgiutils/auth.py
@@ -3,14 +3,14 @@ import logging
 import secrets
 import urllib.parse
 from enum import Enum
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, cast
 
 import aiohttp
 import jwt
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, Query, Request, Response, status
 from fastapi.responses import RedirectResponse
 from fastapi.security import APIKeyHeader, APIKeyQuery
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from c2casgiutils.config import settings
 
@@ -45,11 +45,20 @@ class UserInfo(BaseModel):
     token: str = ""
 
 
+class GitHubSessionPayload(UserInfo):
+    """Typed payload stored in the GitHub auth session cookie."""
+
+    access_token_expires_at: int | None = None
+    refresh_token: str | None = None
+    refresh_token_expires_at: int | None = None
+
+
 class AuthInfo(BaseModel):
     """Details about the authentication status and user information."""
 
     is_logged_in: bool
     user: UserInfo
+    session_payload: GitHubSessionPayload | None = Field(default=None, exclude=True)
 
 
 async def _is_auth_secret(
@@ -93,7 +102,129 @@ async def _is_auth_secret(
     return False
 
 
-async def _is_auth_user_github(request: Request) -> AuthInfo:
+def _logout_user(request: Request, response: Response, auth_info: AuthInfo) -> None:
+    """Clear authentication cookie and reset auth information."""
+    response.delete_cookie(key=settings.auth.jwt.cookie.name, path=_get_jwt_cookie_path(request))
+    auth_info.is_logged_in = False
+    auth_info.user = UserInfo()
+    auth_info.session_payload = None
+
+
+def _now_utc_timestamp() -> int:
+    """Get the current UTC timestamp in seconds."""
+    return int(datetime.datetime.now(datetime.UTC).timestamp())
+
+
+def _is_expired(expiration_timestamp: float | None) -> bool:
+    """Check if a token expiration timestamp is considered expired with margin."""
+    if expiration_timestamp is None:
+        return False
+    return _now_utc_timestamp() + int(
+        settings.auth.github.access_token_expiration_margin.total_seconds()
+    ) >= int(expiration_timestamp)
+
+
+def _apply_token_lifetimes(payload: GitHubSessionPayload, token: dict[str, Any]) -> None:
+    """Apply token expiration fields from an OAuth response payload."""
+    now = _now_utc_timestamp()
+
+    expires_in = token.get("expires_in")
+    if isinstance(expires_in, int | float):
+        payload.access_token_expires_at = now + int(expires_in)
+    else:
+        payload.access_token_expires_at = None
+
+    refresh_token = token.get("refresh_token")
+    if isinstance(refresh_token, str) and refresh_token:
+        payload.refresh_token = refresh_token
+
+    refresh_token_expires_in = token.get("refresh_token_expires_in")
+    if isinstance(refresh_token_expires_in, int | float):
+        payload.refresh_token_expires_at = now + int(refresh_token_expires_in)
+    elif isinstance(refresh_token, str) and refresh_token:
+        payload.refresh_token_expires_at = None
+
+
+async def _refresh_github_access_token(refresh_token: str) -> dict[str, Any] | None:
+    """Try to refresh a GitHub access token."""
+    token_url = settings.auth.github.token_url
+    token_data = {
+        "client_id": settings.auth.github.client_id,
+        "client_secret": settings.auth.github.client_secret,
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+    }
+    headers = {"Accept": "application/json"}
+
+    try:
+        async with (
+            aiohttp.ClientSession() as session,
+            session.post(
+                token_url,
+                data=token_data,
+                headers=headers,
+            ) as response_token,
+        ):
+            if response_token.status != 200:
+                _LOG.info("Unable to refresh GitHub token: %s", await response_token.text())
+                return None
+            token_raw = await response_token.json()
+            if not isinstance(token_raw, dict):
+                _LOG.warning("Invalid refreshed token payload: expected object")
+                return None
+            token = cast("dict[str, Any]", token_raw)
+    except (aiohttp.ClientError, TimeoutError, ValueError) as exception:
+        _LOG.warning("Unable to refresh GitHub token", exc_info=exception)
+        return None
+
+    token_type = token.get("token_type")
+    if token_type is None or token_type.lower() != "bearer":
+        _LOG.warning("Invalid refreshed token type: %r", token_type)
+        return None
+    if not isinstance(token.get("access_token"), str) or not token["access_token"]:
+        _LOG.warning("Invalid refreshed token payload: missing access_token")
+        return None
+    return token
+
+
+async def _ensure_valid_github_token(
+    request: Request,
+    response: Response,
+    auth_info: AuthInfo,
+) -> bool:
+    """Ensure a valid GitHub token is available, refresh or logout if needed."""
+    if not auth_info.is_logged_in:
+        return False
+
+    payload = auth_info.session_payload
+    if payload is None:
+        return False
+
+    if not _is_expired(payload.access_token_expires_at):
+        return True
+
+    refresh_token = payload.refresh_token
+    if not refresh_token:
+        _logout_user(request, response, auth_info)
+        return False
+    if _is_expired(payload.refresh_token_expires_at):
+        _logout_user(request, response, auth_info)
+        return False
+
+    token = await _refresh_github_access_token(refresh_token)
+    if token is None:
+        _logout_user(request, response, auth_info)
+        return False
+
+    payload.token = token["access_token"]
+    _apply_token_lifetimes(payload, token)
+    _set_jwt_cookie(request, response, payload=payload.model_dump(exclude_none=True))
+    auth_info.user.token = token["access_token"]
+    auth_info.session_payload = payload
+    return True
+
+
+async def _is_auth_user_github(request: Request, response: Response) -> AuthInfo:
     if settings.auth.test.username is not None:
         # For testing purposes, we can return a fake user
         return AuthInfo(
@@ -108,10 +239,23 @@ async def _is_auth_user_github(request: Request) -> AuthInfo:
     try:
         user_payload = _get_jwt_cookie(request)
     except jwt.ExpiredSignatureError as jwt_exception:
+        response.delete_cookie(key=settings.auth.jwt.cookie.name, path=_get_jwt_cookie_path(request))
         raise HTTPException(401, "Expired session") from jwt_exception
     except jwt.InvalidTokenError as jwt_exception:
+        response.delete_cookie(key=settings.auth.jwt.cookie.name, path=_get_jwt_cookie_path(request))
         raise HTTPException(401, "Invalid session") from jwt_exception
-    return AuthInfo(is_logged_in=user_payload is not None, user=UserInfo(**(user_payload or {})))
+
+    auth_info = AuthInfo(
+        is_logged_in=user_payload is not None,
+        user=UserInfo(**(user_payload or {})),
+        session_payload=user_payload,
+    )
+
+    if not auth_info.is_logged_in:
+        return auth_info
+
+    await _ensure_valid_github_token(request, response, auth_info)
+    return auth_info
 
 
 async def get_auth(request: Request, response: Response) -> AuthInfo:
@@ -138,7 +282,7 @@ async def get_auth(request: Request, response: Response) -> AuthInfo:
     if auth_type_ == AuthenticationType.SECRET:
         return AuthInfo(is_logged_in=await _is_auth_secret(request, response), user=UserInfo())
     if auth_type_ == AuthenticationType.GITHUB:
-        return await _is_auth_user_github(request)
+        return await _is_auth_user_github(request, response)
 
     return AuthInfo(is_logged_in=False, user=UserInfo())
 
@@ -202,6 +346,8 @@ async def startup(main_app: FastAPI) -> None:
 async def check_access(
     auth_info: Annotated[AuthInfo, Depends(get_auth)],
     auth_config: AuthConfig,
+    request: Request | None = None,
+    response: Response | None = None,
 ) -> bool:
     """
     Check if the user has access to the resource.
@@ -211,13 +357,22 @@ async def check_access(
     if not auth_info.is_logged_in:
         return False
 
-    if await check_admin_access(auth_info):
+    if await check_admin_access(auth_info, request=request, response=response):
         return True
 
-    return await check_access_config(auth_info, auth_config)
+    return await check_access_config(
+        auth_info,
+        auth_config,
+        request=request,
+        fastapi_response=response,
+    )
 
 
-async def check_admin_access(auth_info: Annotated[AuthInfo, Depends(get_auth)]) -> bool:
+async def check_admin_access(
+    auth_info: Annotated[AuthInfo, Depends(get_auth)],
+    request: Request | None = None,
+    response: Response | None = None,
+) -> bool:
     """Check if the user has admin access to the resource."""
     if not auth_info.is_logged_in:
         return False
@@ -225,12 +380,19 @@ async def check_admin_access(auth_info: Annotated[AuthInfo, Depends(get_auth)]) 
     if auth_type() != AuthenticationType.GITHUB:
         return True
 
-    return await check_access_config(auth_info, ADMIN_AUTH_CONFIG)
+    return await check_access_config(
+        auth_info,
+        ADMIN_AUTH_CONFIG,
+        request=request,
+        fastapi_response=response,
+    )
 
 
 async def check_access_config(
     auth_info: Annotated[AuthInfo, Depends(get_auth)],
     auth_config: AuthConfig,
+    request: Request | None = None,
+    fastapi_response: Response | None = None,
 ) -> bool:
     """Check if the user has access to the resource."""
     if not auth_info.is_logged_in:
@@ -248,9 +410,17 @@ async def check_access_config(
         session.get(
             f"{repo_url}/{auth_config.github_repository}",
             headers=headers,
-        ) as response,
+        ) as github_response,
     ):
-        repository = await response.json()
+        if github_response.status == 401:
+            if request is not None and fastapi_response is not None:
+                _logout_user(request, fastapi_response, auth_info)
+            else:
+                auth_info.is_logged_in = False
+                auth_info.user = UserInfo()
+                auth_info.session_payload = None
+            return False
+        repository = await github_response.json()
         return not (
             "permissions" not in repository
             or repository["permissions"][auth_config.github_access_type] is not True
@@ -260,18 +430,28 @@ async def check_access_config(
 async def require_access(
     auth_info: Annotated[AuthInfo, Depends(get_auth)],
     auth_config: AuthConfig,
+    request: Request,
+    response: Response,
 ) -> None:
     """
     FastAPI dependency that requires GitHub repository access.
 
     Usage:
         @app.get("/protected")
-        async def protected_route(_: Annotated[bool, Depends(
-            lambda auth: require_access(auth_info, {"github_repository": "org/repo", "github_access_type": "admin"})
-        )]):
+        async def protected_route(
+            auth_info: Annotated[AuthInfo, Depends(get_auth)],
+            request: Request,
+            response: Response,
+        ):
+            await require_access(
+                auth_info,
+                AuthConfig(github_repository="org/repo", github_access_type="admin"),
+                request,
+                response,
+            )
             return {"message": "You have access"}
     """
-    if not await check_access(auth_info, auth_config):
+    if not await check_access(auth_info, auth_config, request=request, response=response):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You don't have access to this resource",
@@ -280,6 +460,8 @@ async def require_access(
 
 async def require_admin_access(
     auth_info: Annotated[AuthInfo, Depends(get_auth)],
+    request: Request,
+    response: Response,
 ) -> None:
     """FastAPI dependency that requires admin access.
 
@@ -288,7 +470,7 @@ async def require_admin_access(
         async def admin_protected_route(_: Annotated[bool, Depends(require_admin_access)]):
             return {"message": "You have admin access"}
     """
-    if not await check_admin_access(auth_info):
+    if not await check_admin_access(auth_info, request=request, response=response):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You don't have admin access to this resource",
@@ -673,7 +855,9 @@ if _auth_type == AuthenticationType.GITHUB:
             url=user["html_url"],
             token=token["access_token"],
         )
-        _set_jwt_cookie(request, response, payload=user_information.model_dump())
+        payload = GitHubSessionPayload(**user_information.model_dump())
+        _apply_token_lifetimes(payload, token)
+        _set_jwt_cookie(request, response, payload=payload.model_dump(exclude_none=True))
 
         # Redirect to success page or front page
         redirect_after_login = came_from or str(request.url_for("c2c_index"))

--- a/c2casgiutils/config.py
+++ b/c2casgiutils/config.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import os
 from pathlib import Path
@@ -120,6 +121,23 @@ class Sentry(BaseModel):
         return self
 
 
+class _IsoTimedelta(datetime.timedelta):
+    def __str__(self) -> str:
+        total_seconds = int(self.total_seconds())
+        hours, remainder = divmod(total_seconds, 3600)
+        minutes, seconds = divmod(remainder, 60)
+
+        parts = []
+        if hours > 0:
+            parts.append(f"{hours}H")
+        if minutes > 0:
+            parts.append(f"{minutes}M")
+        if seconds > 0:
+            parts.append(f"{seconds}S")
+
+        return f"PT{''.join(parts)}" if parts else "PT0S"
+
+
 class AuthGitHub(BaseModel):
     """GitHub Authentication settings."""
 
@@ -150,6 +168,24 @@ class AuthGitHub(BaseModel):
         int,
         Field(description="GitHub state cookie age in seconds (default: 10 minutes)"),
     ] = 10 * 60  # 10 minutes
+    access_token_expiration_margin: Annotated[
+        datetime.timedelta,
+        Field(
+            description=(
+                "Safety margin applied before checking GitHub access token expiration. "
+                "Accepts ISO 8601 durations (e.g.: `PT1M` for 1 minute)."
+            ),
+        ),
+    ] = _IsoTimedelta(minutes=1)
+
+    @field_validator("access_token_expiration_margin")
+    @classmethod
+    def validate_access_token_expiration_margin(cls, value: datetime.timedelta) -> datetime.timedelta:
+        """Validate that access_token_expiration_margin is not negative."""
+        if value < datetime.timedelta(0):
+            message = "C2C__AUTH__GITHUB__ACCESS_TOKEN_EXPIRATION_MARGIN must be >= PT0S"
+            raise ValueError(message)
+        return value
 
 
 class AuthJWTCookie(BaseModel):

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -1,0 +1,289 @@
+from unittest.mock import AsyncMock, Mock, patch
+
+import aiohttp
+import pytest
+from fastapi import Response
+from starlette.requests import Request
+
+from c2casgiutils import auth
+
+
+def _request() -> Request:
+    return Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "http",
+            "path": "/",
+            "raw_path": b"/",
+            "query_string": b"",
+            "headers": [],
+            "client": ("127.0.0.1", 1234),
+            "server": ("testserver", 80),
+        }
+    )
+
+
+@pytest.fixture
+def fixed_cookie_path() -> str:
+    previous = auth.settings.auth.jwt.cookie.path
+    auth.settings.auth.jwt.cookie.path = "/"
+    yield "/"
+    auth.settings.auth.jwt.cookie.path = previous
+
+
+def _mock_github_get_response(status: int, payload: dict) -> Mock:
+    github_response = Mock()
+    github_response.status = status
+    github_response.json = AsyncMock(return_value=payload)
+    return github_response
+
+
+def _setup_client_session_get(mock_client_session: Mock, github_response: Mock) -> None:
+    session = Mock()
+    get_cm = AsyncMock()
+    get_cm.__aenter__.return_value = github_response
+    get_cm.__aexit__.return_value = None
+    session.get.return_value = get_cm
+
+    session_cm = AsyncMock()
+    session_cm.__aenter__.return_value = session
+    session_cm.__aexit__.return_value = None
+    mock_client_session.return_value = session_cm
+
+
+@pytest.mark.asyncio
+async def test_ensure_valid_github_token_refreshes_expired_token(fixed_cookie_path):
+    auth_info = auth.AuthInfo(
+        is_logged_in=True,
+        user=auth.UserInfo(login="john", token="old-token"),
+        session_payload=auth.GitHubSessionPayload(
+            login="john",
+            display_name="John",
+            url="https://example.com/john",
+            token="old-token",
+            access_token_expires_at=auth._now_utc_timestamp() - 1,
+            refresh_token="refresh-token",
+            refresh_token_expires_at=auth._now_utc_timestamp() + 3600,
+        ),
+    )
+    request = _request()
+    response = Response()
+
+    refreshed_token = {
+        "access_token": "new-token",
+        "token_type": "bearer",
+        "expires_in": 3600,
+        "refresh_token": "new-refresh-token",
+        "refresh_token_expires_in": 7200,
+    }
+
+    github_response = _mock_github_get_response(200, {"permissions": {"pull": True}})
+
+    with (
+        patch("c2casgiutils.auth._refresh_github_access_token", new=AsyncMock(return_value=refreshed_token)),
+        patch("c2casgiutils.auth._set_jwt_cookie") as mock_set_cookie,
+        patch("c2casgiutils.auth.aiohttp.ClientSession") as mock_client_session,
+    ):
+        _setup_client_session_get(mock_client_session, github_response)
+
+        has_access = await auth._ensure_valid_github_token(request, response, auth_info)
+
+    assert has_access is True
+    assert auth_info.user.token == "new-token"
+    assert auth_info.is_logged_in is True
+    assert auth_info.session_payload is not None
+    assert auth_info.session_payload.token == "new-token"
+    assert auth_info.session_payload.access_token_expires_at is not None
+    mock_set_cookie.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_ensure_valid_github_token_logs_out_when_refresh_fails(fixed_cookie_path):
+    auth_info = auth.AuthInfo(
+        is_logged_in=True,
+        user=auth.UserInfo(login="john", token="expired-token"),
+        session_payload=auth.GitHubSessionPayload(
+            login="john",
+            display_name="John",
+            url="https://example.com/john",
+            token="expired-token",
+            access_token_expires_at=auth._now_utc_timestamp() - 1,
+            refresh_token="refresh-token",
+            refresh_token_expires_at=auth._now_utc_timestamp() + 3600,
+        ),
+    )
+
+    with patch("c2casgiutils.auth._refresh_github_access_token", new=AsyncMock(return_value=None)):
+        has_access = await auth._ensure_valid_github_token(_request(), Response(), auth_info)
+
+    assert has_access is False
+    assert auth_info.is_logged_in is False
+    assert auth_info.user.token == ""
+    assert auth_info.session_payload is None
+
+
+@pytest.mark.asyncio
+async def test_ensure_valid_github_token_logs_out_when_no_refresh_token(fixed_cookie_path):
+    auth_info = auth.AuthInfo(
+        is_logged_in=True,
+        user=auth.UserInfo(login="john", token="expired-token"),
+        session_payload=auth.GitHubSessionPayload(
+            login="john",
+            display_name="John",
+            url="https://example.com/john",
+            token="expired-token",
+            access_token_expires_at=auth._now_utc_timestamp() - 1,
+        ),
+    )
+
+    has_access = await auth._ensure_valid_github_token(_request(), Response(), auth_info)
+
+    assert has_access is False
+    assert auth_info.is_logged_in is False
+    assert auth_info.user.token == ""
+    assert auth_info.session_payload is None
+
+
+@pytest.mark.asyncio
+async def test_check_access_config_denies_without_logout_when_missing_permission(fixed_cookie_path):
+    auth_info = auth.AuthInfo(
+        is_logged_in=True,
+        user=auth.UserInfo(login="john", token="valid-token"),
+        session_payload=auth.GitHubSessionPayload(
+            login="john",
+            display_name="John",
+            url="https://example.com/john",
+            token="valid-token",
+            access_token_expires_at=auth._now_utc_timestamp() + 3600,
+        ),
+    )
+
+    github_response = _mock_github_get_response(200, {"permissions": {"pull": False}})
+    with patch("c2casgiutils.auth.aiohttp.ClientSession") as mock_client_session:
+        _setup_client_session_get(mock_client_session, github_response)
+
+        has_access = await auth.check_access_config(
+            auth_info,
+            auth.AuthConfig(github_repository="camptocamp/tilecloud-chain", github_access_type="pull"),
+            request=_request(),
+            fastapi_response=Response(),
+        )
+
+    assert has_access is False
+    assert auth_info.is_logged_in is True
+    assert auth_info.user.token == "valid-token"
+
+
+@pytest.mark.asyncio
+async def test_check_access_config_does_not_refresh_token(fixed_cookie_path):
+    auth_info = auth.AuthInfo(
+        is_logged_in=True,
+        user=auth.UserInfo(login="john", token="expired-token"),
+        session_payload=auth.GitHubSessionPayload(
+            login="john",
+            display_name="John",
+            url="https://example.com/john",
+            token="expired-token",
+            access_token_expires_at=auth._now_utc_timestamp() - 1,
+            refresh_token="refresh-token",
+            refresh_token_expires_at=auth._now_utc_timestamp() + 3600,
+        ),
+    )
+
+    github_response = _mock_github_get_response(200, {"permissions": {"pull": True}})
+
+    with (
+        patch(
+            "c2casgiutils.auth._ensure_valid_github_token", new=AsyncMock(return_value=False)
+        ) as mock_ensure,
+        patch("c2casgiutils.auth.aiohttp.ClientSession") as mock_client_session,
+    ):
+        _setup_client_session_get(mock_client_session, github_response)
+
+        has_access = await auth.check_access_config(
+            auth_info,
+            auth.AuthConfig(github_repository="camptocamp/tilecloud-chain", github_access_type="pull"),
+            request=_request(),
+            fastapi_response=Response(),
+        )
+
+    assert has_access is True
+    assert auth_info.is_logged_in is True
+    assert auth_info.user.token == "expired-token"
+    mock_ensure.assert_not_called()
+
+
+def test_apply_token_lifetimes_clears_stale_refresh_expiration():
+    payload = auth.GitHubSessionPayload(
+        refresh_token="old-refresh", refresh_token_expires_at=auth._now_utc_timestamp() + 10
+    )
+
+    auth._apply_token_lifetimes(
+        payload,
+        {
+            "access_token": "new-token",
+            "token_type": "bearer",
+            "refresh_token": "new-refresh",
+        },
+    )
+
+    assert payload.refresh_token == "new-refresh"
+    assert payload.refresh_token_expires_at is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_github_access_token_handles_network_error():
+    with patch("c2casgiutils.auth.aiohttp.ClientSession", side_effect=aiohttp.ClientError("boom")):
+        token = await auth._refresh_github_access_token("refresh-token")
+
+    assert token is None
+
+
+@pytest.mark.asyncio
+async def test_access_context_require_access_raises_forbidden():
+    access_context = auth.AccessContext(
+        auth_info=auth.AuthInfo(is_logged_in=False, user=auth.UserInfo()),
+        request=_request(),
+        response=Response(),
+    )
+
+    with pytest.raises(auth.HTTPException) as exception:
+        await access_context.require_access(
+            auth.AuthConfig(github_repository="camptocamp/tilecloud-chain", github_access_type="pull")
+        )
+
+    assert exception.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_is_auth_user_github_clears_cookie_on_expired_jwt(fixed_cookie_path):
+    response = Response()
+
+    with (
+        patch("c2casgiutils.auth._get_jwt_cookie", side_effect=auth.jwt.ExpiredSignatureError("expired")),
+        pytest.raises(auth.HTTPException) as exception,
+    ):
+        await auth._is_auth_user_github(_request(), response)
+
+    assert exception.value.status_code == 401
+    assert "set-cookie" in response.headers
+    assert f"{auth.settings.auth.jwt.cookie.name}=" in response.headers["set-cookie"]
+    assert "Max-Age=0" in response.headers["set-cookie"]
+
+
+@pytest.mark.asyncio
+async def test_is_auth_user_github_clears_cookie_on_invalid_jwt(fixed_cookie_path):
+    response = Response()
+
+    with (
+        patch("c2casgiutils.auth._get_jwt_cookie", side_effect=auth.jwt.InvalidTokenError("invalid")),
+        pytest.raises(auth.HTTPException) as exception,
+    ):
+        await auth._is_auth_user_github(_request(), response)
+
+    assert exception.value.status_code == 401
+    assert "set-cookie" in response.headers
+    assert f"{auth.settings.auth.jwt.cookie.name}=" in response.headers["set-cookie"]
+    assert "Max-Age=0" in response.headers["set-cookie"]

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 
 import pytest
@@ -123,3 +124,11 @@ def test_proxy_headers_forwarded_type(clean_env):
     settings = Settings()
 
     assert settings.proxy_headers.type == "forwarded"
+
+
+def test_auth_github_access_token_expiration_margin_from_environment(clean_env):
+    os.environ["C2C__AUTH__GITHUB__ACCESS_TOKEN_EXPIRATION_MARGIN"] = "PT2M30S"
+
+    settings = Settings()
+
+    assert settings.auth.github.access_token_expiration_margin == datetime.timedelta(minutes=2, seconds=30)


### PR DESCRIPTION
## Summary
- refresh expired GitHub OAuth access tokens when lifetime metadata is available in the auth cookie
- automatically clear the auth cookie and log users out when refresh is unavailable or fails, avoiding the logged-in-without-rights state
- replace untyped GitHub session payload data with a dedicated typed Pydantic model
- add a configurable token-expiration safety margin with `C2C__AUTH__GITHUB__ACCESS_TOKEN_EXPIRATION_MARGIN` (ISO 8601 duration, default `PT1M`)
- add an injectable `AccessContext` to centralize auth data (`auth_info`, `request`, `response`) used by access checks
- add focused auth/config tests and update README/CHANGELOG documentation for the new behavior

## Commit Structure
- **Commit 1** (`Handle expired GitHub OAuth sessions cleanly`): implements token refresh/logout flow, typed session payload, expiration margin, tests, and docs
- **Commit 2** (`Simplify require access`): introduced because `check_access`, `check_admin_access`, and `check_access_config` were starting to have too many parameters; this commit centralizes those request-scoped values into `AccessContext` to simplify usage and improve readability
