### PR TITLE
Fallback to user login when GitHub display name is null

### DIFF
--- a/c2casgiutils/auth.py
+++ b/c2casgiutils/auth.py
@@ -903,7 +903,7 @@ if _auth_type == AuthenticationType.GITHUB:
 
         user_information = UserInfo(
             login=user["login"],
-            display_name=user["name"],
+            display_name=user.get("name") or user["login"],
             url=user["html_url"],
             token=token["access_token"],
         )


### PR DESCRIPTION
## Summary

When GitHub API returns `name: null` for a user, `UserInfo(display_name=user["name"])` throws a Pydantic validation error. Fallback to `user["login"]` when `name` is absent/null.

## Context

- Sentry issue: https://camptocamp.sentry.io/issues/7626297773/

## Implementation Details

- `display_name=user.get("name") or user["login"]` handles `None` name from GitHub
