### PR TITLE
Add GitHub token authentication and read-only/read-write/admin access levels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,10 @@ The project must use async-friendly I/O APIs to avoid blocking the event loop.
 - All disk or network operation must be done with async API; avoid blocking calls on the event loop.
 - Don't allow sequential `await` calls in loops; use e.g. `asyncio.gather` or `asyncio.TaskGroup`.
 
+## Dependency management
+
+This project uses Poetry, not uv. The `uv.lock` file should not be committed.
+
 ## Environment variables
 
 The environment variable should not be accessed directly (except the ones defined by another project); they should be defined in the `Settings` class in `c2casgiutils/config.py` and accessed through the `settings` object.
@@ -86,3 +90,5 @@ To check the code quality, use the `make prospector` command.
 ## Changelog
 
 The [changelog](./CHANGELOG.md) should respect the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) rules.
+
+Before modifying the changelog, check if a release has been made since the last edit by looking at the git tags and GitHub releases. If a release was made, add a new section for the `[Unreleased]` changes instead of modifying the released version's section.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **GitHub token authentication**: Added support for GitHub Personal Access Token (PAT) authentication via the `Authorization: Bearer <token>` HTTP header. AI agents and other clients can now authenticate programmatically without going through the OAuth web flow. The token is validated by calling the GitHub `/user` API.
+- **Read-only, read-write and admin access levels**: Replaced the single `access_type` setting with `access_type_read_only` (default: `pull`), `access_type_read_write` (default: `push`), and `access_type_admin` (default: `admin`) to allow finer-grained access control. The set log level endpoint now requires read-write access, while read-only operations (viewing headers, logging levels) only require read-only access.
+- **Auth method tracking**: Added `AuthMethod` enum and `type` field to `AuthInfo` to indicate how the user authenticated (`github_oauth`, `github_bearer`, `secret`, `test`, `none`).
+
+### Changed
+
+- **GitHub auth settings**: The `C2C__AUTH__GITHUB__ACCESS_TYPE` environment variable has been replaced by `C2C__AUTH__GITHUB__ACCESS_TYPE_READ_ONLY`, `C2C__AUTH__GITHUB__ACCESS_TYPE_READ_WRITE`, and `C2C__AUTH__GITHUB__ACCESS_TYPE_ADMIN`.
+- **Auth dependency ergonomics**: Added `require_read_only_access`, `require_read_write_access`, `require_admin_access`, `check_read_only_access`, `check_read_write_access`, and `check_admin_access` helpers with separate access levels.
+- **GitHub access types as enum**: `GitHubAccessType` is now a `StrEnum` (`pull`, `push`, `admin`) instead of a plain string.
+
+## [0.13.1] - 2026-07-23
+
+### Changed
+
+- **GitHub display name**: Fallback to user login when GitHub display name is null.
+
+## [0.13.0] - 2026-07-14
+
+### Added
+
+- **Duration type**: Added `Duration` type with short format and ISO 8601 duration parsing support.
+- **Redis options parsing**: Moved Redis options parsing to `config.py` as a computed field.
+
+## [0.12.0] - 2026-07-07
+
 ### Changed
 
 - **Async I/O compliance**: Replaced `aiofiles` usage in CLI logging config loading with `anyio.Path`, and removed direct `aiofiles` dependency from project metadata.
-- **GitHub auth sessions**: GitHub OAuth sessions now attempt to refresh expired access tokens automatically. If refresh is unavailable or fails, the auth cookie is cleared so users are logged out instead of remaining logged-in without repository permissions.
 - **Auth dependency ergonomics**: Added injectable `AccessContext` helpers with the methods `require_access`, `require_admin_access`, `check_access` and `check_admin_access` to simplify route protection code.
+- **GitHub auth sessions**: GitHub OAuth sessions now attempt to refresh expired access tokens automatically. If refresh is unavailable or fails, the auth cookie is cleared so users are logged out instead of remaining logged-in without repository permissions.
 - **GitHub auth expiration**: Added a configurable token expiration safety margin with `C2C__AUTH__GITHUB__ACCESS_TOKEN_EXPIRATION_MARGIN` (ISO 8601 duration, default `PT1M`) and removed duplicate token-refresh checks inside `check_access_config`.
 
 ## [0.11.0] - 2026-04-17

--- a/README.md
+++ b/README.md
@@ -827,11 +827,35 @@ Secret key for trivial authentication (not secure)
 
 GitHub repository for authentication
 
-### `C2C__AUTH__GITHUB__ACCESS_TYPE`
+### `C2C__AUTH__GITHUB__ACCESS_TYPE_READ_ONLY`
 
 *Optional*, default value: `pull`
 
-GitHub access type
+GitHub access type required for read-only operations
+
+#### Possible values
+
+`pull`, `push`, `admin`
+
+### `C2C__AUTH__GITHUB__ACCESS_TYPE_READ_WRITE`
+
+*Optional*, default value: `push`
+
+GitHub access type required for read-write operations
+
+#### Possible values
+
+`pull`, `push`, `admin`
+
+### `C2C__AUTH__GITHUB__ACCESS_TYPE_ADMIN`
+
+*Optional*, default value: `admin`
+
+GitHub access type required for admin operations
+
+#### Possible values
+
+`pull`, `push`, `admin`
 
 ### `C2C__AUTH__GITHUB__AUTHORIZE_URL`
 

--- a/acceptance_tests/fastapi_app/docker-compose.yaml
+++ b/acceptance_tests/fastapi_app/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
       - C2C__AUTH__GITHUB__CLIENT_ID=***
       - C2C__AUTH__GITHUB__CLIENT_SECRET=***
       - C2C__AUTH__GITHUB__REPOSITORY=camptocamp/geomapfish
-      - C2C__AUTH__GITHUB__ACCESS_TYPE=admin
+      - C2C__AUTH__GITHUB__ACCESS_TYPE_ADMIN=admin
       - C2C__AUTH__GITHUB__SCOPE=repo
       - C2C__AUTH__GITHUB__PROXY_URL=https://geoservices-int.camptocamp.com/redirect
       - C2C__HTTP=True
@@ -28,7 +28,7 @@ services:
       - C2C__AUTH__GITHUB__CLIENT_ID=***
       - C2C__AUTH__GITHUB__CLIENT_SECRET=***
       - C2C__AUTH__GITHUB__REPOSITORY=camptocamp/geomapfish
-      - C2C__AUTH__GITHUB__ACCESS_TYPE=admin
+      - C2C__AUTH__GITHUB__ACCESS_TYPE_ADMIN=admin
       - C2C__AUTH__GITHUB__SCOPE=repo
       - C2C__AUTH__GITHUB__PROXY_URL=https://geoservices-int.camptocamp.com/redirect
       - C2C__AUTH__TEST__USERNAME=TestUser

--- a/c2casgiutils/auth.py
+++ b/c2casgiutils/auth.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 import secrets
 import urllib.parse
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import Annotated, Any, Literal, cast
 
 import aiohttp
@@ -12,7 +12,7 @@ from fastapi.responses import RedirectResponse
 from fastapi.security import APIKeyHeader, APIKeyQuery
 from pydantic import BaseModel, Field, ValidationError
 
-from c2casgiutils.config import settings
+from c2casgiutils.config import GitHubAccessType, settings
 
 _LOG = logging.getLogger(__name__)
 
@@ -26,13 +26,27 @@ class AuthConfig(BaseModel):
 
     # The repository to check access to (<organization>/<repository>).
     github_repository: str | None = None
-    # The type of access to check (admin|push|pull).
-    github_access_type: str | None = None
+    # The type of access to check for read-only operations (pull|push|admin).
+    github_access_type_read_only: GitHubAccessType | None = None
+    # The type of access to check for read-write operations (pull|push|admin).
+    github_access_type_read_write: GitHubAccessType | None = None
+    # The type of access to check for admin operations (pull|push|admin).
+    github_access_type_admin: GitHubAccessType | None = None
 
+
+READ_ONLY_AUTH_CONFIG = AuthConfig(
+    github_repository=settings.auth.github.repository,
+    github_access_type_read_only=settings.auth.github.access_type_read_only,
+)
+
+READ_WRITE_AUTH_CONFIG = AuthConfig(
+    github_repository=settings.auth.github.repository,
+    github_access_type_read_write=settings.auth.github.access_type_read_write,
+)
 
 ADMIN_AUTH_CONFIG = AuthConfig(
     github_repository=settings.auth.github.repository,
-    github_access_type="admin",
+    github_access_type_admin=settings.auth.github.access_type_admin,
 )
 
 
@@ -53,12 +67,23 @@ class GitHubSessionPayload(UserInfo):
     refresh_token_expires_at: int | None = None
 
 
+class AuthMethod(StrEnum):
+    """The method used by the current user to authenticate."""
+
+    NONE = "none"
+    SECRET = "secret"  # noqa: S105
+    GITHUB_OAUTH = "github_oauth"
+    GITHUB_BEARER = "github_bearer"
+    TEST = "test"
+
+
 class AuthInfo(BaseModel):
     """Details about the authentication status and user information."""
 
     is_logged_in: bool
     user: UserInfo
     session_payload: GitHubSessionPayload | None = Field(default=None, exclude=True)
+    type: AuthMethod = AuthMethod.NONE
 
 
 class AccessContext:
@@ -73,6 +98,14 @@ class AccessContext:
         """Check whether the current user has access to the configured repository."""
         return await check_access(self.auth_info, auth_config, request=self.request, response=self.response)
 
+    async def check_read_only_access(self) -> bool:
+        """Check whether the current user has read-only access."""
+        return await check_read_only_access(self.auth_info, request=self.request, response=self.response)
+
+    async def check_read_write_access(self) -> bool:
+        """Check whether the current user has read-write access."""
+        return await check_read_write_access(self.auth_info, request=self.request, response=self.response)
+
     async def check_admin_access(self) -> bool:
         """Check whether the current user has admin access."""
         return await check_admin_access(self.auth_info, request=self.request, response=self.response)
@@ -83,6 +116,22 @@ class AccessContext:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="You don't have access to this resource",
+            )
+
+    async def require_read_only_access(self) -> None:
+        """Require read-only access or raise HTTP 403."""
+        if not await self.check_read_only_access():
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You don't have read-only access to this resource",
+            )
+
+    async def require_read_write_access(self) -> None:
+        """Require read-write access or raise HTTP 403."""
+        if not await self.check_read_write_access():
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You don't have read-write access to this resource",
             )
 
     async def require_admin_access(self) -> None:
@@ -290,6 +339,7 @@ async def _is_auth_user_github(request: Request, response: Response) -> AuthInfo
         is_logged_in=user_payload is not None,
         user=UserInfo(**(user_payload or {})),
         session_payload=session_payload,
+        type=AuthMethod.GITHUB_OAUTH if user_payload is not None else AuthMethod.NONE,
     )
 
     if not auth_info.is_logged_in:
@@ -299,12 +349,52 @@ async def _is_auth_user_github(request: Request, response: Response) -> AuthInfo
     return auth_info
 
 
+async def _validate_github_token(token: str) -> tuple[str | None, str | None]:
+    """Validate a GitHub token and return (login, name) or (None, None)."""
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    user_url = settings.auth.github.user_url
+    try:
+        async with (
+            aiohttp.ClientSession() as session,
+            session.get(user_url, headers=headers) as response,
+        ):
+            if response.status != 200:
+                return None, None
+            user = await response.json()
+            return user.get("login"), user.get("name")
+    except (aiohttp.ClientError, TimeoutError, ValueError) as exception:
+        _LOG.warning("Unable to validate GitHub token", exc_info=exception)
+        return None, None
+
+
 async def get_auth(request: Request, response: Response) -> AuthInfo:
     """
     Check if the client is authenticated.
 
     Returns: boolean to indicated if the user is authenticated, and a dictionary with user details.
     """
+    # Check for GitHub token authentication via Authorization: Bearer header
+    auth_header = request.headers.get("authorization")
+    if auth_header and auth_header.startswith("Bearer "):
+        token = auth_header[7:]
+        login, display_name = await _validate_github_token(token)
+        if login:
+            return AuthInfo(
+                is_logged_in=True,
+                user=UserInfo(
+                    login=login,
+                    display_name=display_name or login,
+                    url=f"https://github.com/{login}",
+                    token=token,
+                ),
+                type=AuthMethod.GITHUB_BEARER,
+            )
+        _LOG.warning("Invalid GitHub token in Authorization header")
+        return AuthInfo(is_logged_in=False, user=UserInfo())
+
     auth_type_ = auth_type()
     if auth_type_ == AuthenticationType.TEST:
         # For testing purposes, we can return a fake user
@@ -317,11 +407,15 @@ async def get_auth(request: Request, response: Response) -> AuthInfo:
                 url="https://example.com",
                 token="",  # nosec
             ),
+            type=AuthMethod.TEST,
         )
     if auth_type_ == AuthenticationType.NONE:
         return AuthInfo(is_logged_in=False, user=UserInfo())
     if auth_type_ == AuthenticationType.SECRET:
-        return AuthInfo(is_logged_in=await _is_auth_secret(request, response), user=UserInfo())
+        auth_info = AuthInfo(is_logged_in=await _is_auth_secret(request, response), user=UserInfo())
+        if auth_info.is_logged_in:
+            auth_info.type = AuthMethod.SECRET
+        return auth_info
     if auth_type_ == AuthenticationType.GITHUB:
         return await _is_auth_user_github(request, response)
 
@@ -339,7 +433,7 @@ async def get_access_context(
     Usage:
         @app.get("/protected")
         async def protected_route(access_context: Annotated[AccessContext, Depends(get_access_context)]):
-            await access_context.require_access(AuthConfig(github_repository="org/repo", github_access_type="admin"))
+            await access_context.require_access(AuthConfig(github_repository="org/repo", github_access_type_read_write="admin"))
             return {"message": "You have access"}
     """
     return AccessContext(auth_info, request, response)
@@ -426,12 +520,52 @@ async def check_access(
     )
 
 
+async def check_read_only_access(
+    auth_info: Annotated[AuthInfo, Depends(get_auth)],
+    request: Request | None = None,
+    response: Response | None = None,
+) -> bool:
+    """Check if the user has read-only access to the resource."""
+    if not auth_info.is_logged_in:
+        return False
+
+    if auth_type() != AuthenticationType.GITHUB:
+        return True
+
+    return await check_access_config(
+        auth_info,
+        READ_ONLY_AUTH_CONFIG,
+        request=request,
+        fastapi_response=response,
+    )
+
+
+async def check_read_write_access(
+    auth_info: Annotated[AuthInfo, Depends(get_auth)],
+    request: Request | None = None,
+    response: Response | None = None,
+) -> bool:
+    """Check if the user has read-write access to the resource."""
+    if not auth_info.is_logged_in:
+        return False
+
+    if auth_type() != AuthenticationType.GITHUB:
+        return True
+
+    return await check_access_config(
+        auth_info,
+        READ_WRITE_AUTH_CONFIG,
+        request=request,
+        fastapi_response=response,
+    )
+
+
 async def check_admin_access(
     auth_info: Annotated[AuthInfo, Depends(get_auth)],
     request: Request | None = None,
     response: Response | None = None,
 ) -> bool:
-    """Check if the user has admin access to the resource."""
+    """Check if the user has admin access."""
     if not auth_info.is_logged_in:
         return False
 
@@ -463,6 +597,9 @@ async def check_access_config(
         "Accept": "application/json",
     }
 
+    if not token:
+        return False
+
     async with (
         aiohttp.ClientSession() as session,
         session.get(
@@ -479,10 +616,22 @@ async def check_access_config(
                 auth_info.session_payload = None
             return False
         repository = await github_response.json()
-        return not (
-            "permissions" not in repository
-            or repository["permissions"][auth_config.github_access_type] is not True
-        )
+        if auth_config.github_access_type_admin is not None:
+            return not (
+                "permissions" not in repository
+                or repository["permissions"][auth_config.github_access_type_admin.value] is not True
+            )
+        if auth_config.github_access_type_read_write is not None:
+            return not (
+                "permissions" not in repository
+                or repository["permissions"][auth_config.github_access_type_read_write.value] is not True
+            )
+        if auth_config.github_access_type_read_only is not None:
+            return not (
+                "permissions" not in repository
+                or repository["permissions"][auth_config.github_access_type_read_only.value] is not True
+            )
+        return False
 
 
 async def require_access(
@@ -503,7 +652,7 @@ async def require_access(
         ):
             await require_access(
                 auth_info,
-                AuthConfig(github_repository="org/repo", github_access_type="admin"),
+                AuthConfig(github_repository="org/repo", github_access_type_read_write="admin"),
                 request,
                 response,
             )
@@ -511,6 +660,38 @@ async def require_access(
     """
     access_context = AccessContext(auth_info, request, response)
     await access_context.require_access(auth_config)
+
+
+async def require_read_only_access(
+    auth_info: Annotated[AuthInfo, Depends(get_auth)],
+    request: Request,
+    response: Response,
+) -> None:
+    """FastAPI dependency that requires read-only access.
+
+    Usage:
+        @app.get("/read_only_protected")
+        async def read_only_protected_route(_: Annotated[bool, Depends(require_read_only_access)]):
+            return {"message": "You have read-only access"}
+    """
+    access_context = AccessContext(auth_info, request, response)
+    await access_context.require_read_only_access()
+
+
+async def require_read_write_access(
+    auth_info: Annotated[AuthInfo, Depends(get_auth)],
+    request: Request,
+    response: Response,
+) -> None:
+    """FastAPI dependency that requires read-write access.
+
+    Usage:
+        @app.get("/read_write_protected")
+        async def read_write_protected_route(_: Annotated[bool, Depends(require_read_write_access)]):
+            return {"message": "You have read-write access"}
+    """
+    access_context = AccessContext(auth_info, request, response)
+    await access_context.require_read_write_access()
 
 
 async def require_admin_access(

--- a/c2casgiutils/config.py
+++ b/c2casgiutils/config.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import os
 import re
+from enum import StrEnum
 from pathlib import Path
 from typing import Annotated, Any, Literal, cast
 
@@ -207,6 +208,14 @@ def parse_duration(text: str | datetime.timedelta) -> datetime.timedelta:
 Duration = Annotated[datetime.timedelta, BeforeValidator(parse_duration)]
 
 
+class GitHubAccessType(StrEnum):
+    """GitHub access type for repository permissions."""
+
+    PULL = "pull"
+    PUSH = "push"
+    ADMIN = "admin"
+
+
 class AuthGitHub(BaseModel):
     """GitHub Authentication settings."""
 
@@ -214,7 +223,18 @@ class AuthGitHub(BaseModel):
         str | None,
         Field(description="GitHub repository for authentication"),
     ] = None
-    access_type: Annotated[str, Field(description="GitHub access type")] = "pull"
+    access_type_read_only: Annotated[
+        GitHubAccessType,
+        Field(description="GitHub access type required for read-only operations"),
+    ] = GitHubAccessType.PULL
+    access_type_read_write: Annotated[
+        GitHubAccessType,
+        Field(description="GitHub access type required for read-write operations"),
+    ] = GitHubAccessType.PUSH
+    access_type_admin: Annotated[
+        GitHubAccessType,
+        Field(description="GitHub access type required for admin operations"),
+    ] = GitHubAccessType.ADMIN
     authorize_url: Annotated[
         str,
         Field(description="GitHub OAuth authorization URL"),

--- a/c2casgiutils/tools/__init__.py
+++ b/c2casgiutils/tools/__init__.py
@@ -27,13 +27,13 @@ router.include_router(
     headers.router,
     prefix="/headers",
     tags=["c2c_headers"],
-    dependencies=[Depends(auth.require_admin_access)],
+    dependencies=[Depends(auth.require_read_only_access)],
 )
 router.include_router(
     logging_tools.router,
     prefix="/logging",
     tags=["c2c_logging"],
-    dependencies=[Depends(auth.require_admin_access)],
+    dependencies=[Depends(auth.require_read_only_access)],
 )
 
 
@@ -73,7 +73,7 @@ async def c2c_index(request: Request, auth_info: Annotated[auth.AuthInfo, Depend
             {
                 "request": request,
                 "is_auth": auth_info.is_logged_in,
-                "has_access": await auth.check_admin_access(auth_info),
+                "has_access": await auth.check_read_only_access(auth_info),
                 "user": auth_info.user,
                 "auth_type": auth.auth_type(),
                 "AuthenticationType": auth.AuthenticationType,

--- a/c2casgiutils/tools/headers.py
+++ b/c2casgiutils/tools/headers.py
@@ -72,7 +72,7 @@ async def _c2c_headers(request: Request) -> HeadersResponse:
 @router.get("/")
 async def c2c_headers(
     request: Request,
-    _: Annotated[None, Depends(auth.require_admin_access)],
+    _: Annotated[None, Depends(auth.require_read_only_access)],
 ) -> HeadersResponse:
     """Get the headers of the request."""
 
@@ -84,7 +84,7 @@ async def c2c_headers_path(
     request: Request,
     path: str,
     param: Annotated[str | None, Query(description="An optional query parameter")] = None,
-    _: Annotated[None, Depends(auth.require_admin_access)] = None,
+    _: Annotated[None, Depends(auth.require_read_only_access)] = None,
 ) -> HeadersResponse:
     """Get the headers of the request with one path."""
     del path, param  # Unused path parameter, but required by FastAPI
@@ -99,7 +99,7 @@ async def c2c_headers_path2(
     path_2: str,
     param_1: Annotated[str | None, Query(description="An optional query parameter")] = None,
     param_2: Annotated[str | None, Query(description="A second optional query parameter")] = None,
-    _: Annotated[None, Depends(auth.require_admin_access)] = None,
+    _: Annotated[None, Depends(auth.require_read_only_access)] = None,
 ) -> HeadersResponse:
     """Get the headers of the request with two path."""
     del path_1, path_2, param_1, param_2  # Unused path parameters, but required by FastAPI

--- a/c2casgiutils/tools/logging_.py
+++ b/c2casgiutils/tools/logging_.py
@@ -48,7 +48,7 @@ _set_level: _SetLevelFunction
 @router.get("/level")
 async def c2c_logging_level(
     name: Annotated[str, Query(description="Name of the logger to get the level for")],
-    _: Annotated[None, Depends(auth.require_admin_access)],
+    _: Annotated[None, Depends(auth.require_read_only_access)],
 ) -> LevelResponse:
     """Get the logging level."""
 
@@ -68,7 +68,7 @@ class _SetLevel(BaseModel):
 @router.post("/level")
 async def c2c_logging_set_level(
     level: _SetLevel,
-    _: Annotated[None, Depends(auth.require_admin_access)],
+    _: Annotated[None, Depends(auth.require_read_write_access)],
 ) -> LevelResponse:
     """Change the logging level."""
 
@@ -90,7 +90,7 @@ async def c2c_logging_set_level(
 
 @router.get("/overrides")
 async def c2c_logging_overrides(
-    _: Annotated[None, Depends(auth.require_admin_access)],
+    _: Annotated[None, Depends(auth.require_read_only_access)],
 ) -> OverridesResponse:
     """Get the logging overrides."""
 

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -6,6 +6,7 @@ from fastapi import Response
 from starlette.requests import Request
 
 from c2casgiutils import auth
+from c2casgiutils.config import GitHubAccessType
 
 
 def _request() -> Request:
@@ -19,6 +20,23 @@ def _request() -> Request:
             "raw_path": b"/",
             "query_string": b"",
             "headers": [],
+            "client": ("127.0.0.1", 1234),
+            "server": ("testserver", 80),
+        }
+    )
+
+
+def _request_with_auth_header(token: str) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "http",
+            "path": "/",
+            "raw_path": b"/",
+            "query_string": b"",
+            "headers": [(b"authorization", f"Bearer {token}".encode())],
             "client": ("127.0.0.1", 1234),
             "server": ("testserver", 80),
         }
@@ -166,7 +184,10 @@ async def test_check_access_config_denies_without_logout_when_missing_permission
 
         has_access = await auth.check_access_config(
             auth_info,
-            auth.AuthConfig(github_repository="camptocamp/tilecloud-chain", github_access_type="pull"),
+            auth.AuthConfig(
+                github_repository="camptocamp/tilecloud-chain",
+                github_access_type_read_only=GitHubAccessType.PULL,
+            ),
             request=_request(),
             fastapi_response=Response(),
         )
@@ -204,7 +225,10 @@ async def test_check_access_config_does_not_refresh_token(fixed_cookie_path):
 
         has_access = await auth.check_access_config(
             auth_info,
-            auth.AuthConfig(github_repository="camptocamp/tilecloud-chain", github_access_type="pull"),
+            auth.AuthConfig(
+                github_repository="camptocamp/tilecloud-chain",
+                github_access_type_read_only=GitHubAccessType.PULL,
+            ),
             request=_request(),
             fastapi_response=Response(),
         )
@@ -251,7 +275,10 @@ async def test_access_context_require_access_raises_forbidden():
 
     with pytest.raises(auth.HTTPException) as exception:
         await access_context.require_access(
-            auth.AuthConfig(github_repository="camptocamp/tilecloud-chain", github_access_type="pull")
+            auth.AuthConfig(
+                github_repository="camptocamp/tilecloud-chain",
+                github_access_type_read_only=GitHubAccessType.PULL,
+            )
         )
 
     assert exception.value.status_code == 403
@@ -287,3 +314,181 @@ async def test_is_auth_user_github_clears_cookie_on_invalid_jwt(fixed_cookie_pat
     assert "set-cookie" in response.headers
     assert f"{auth.settings.auth.jwt.cookie.name}=" in response.headers["set-cookie"]
     assert "Max-Age=0" in response.headers["set-cookie"]
+
+
+@pytest.mark.asyncio
+async def test_validate_github_token_success():
+    token = "valid-token"
+    user_response = Mock()
+    user_response.status = 200
+    user_response.json = AsyncMock(return_value={"login": "testuser", "name": "Test User"})
+
+    session = Mock()
+    get_cm = AsyncMock()
+    get_cm.__aenter__.return_value = user_response
+    get_cm.__aexit__.return_value = None
+    session.get.return_value = get_cm
+
+    session_cm = AsyncMock()
+    session_cm.__aenter__.return_value = session
+    session_cm.__aexit__.return_value = None
+
+    with patch("c2casgiutils.auth.aiohttp.ClientSession", return_value=session_cm):
+        login, name = await auth._validate_github_token(token)
+
+    assert login == "testuser"
+    assert name == "Test User"
+    session.get.assert_called_once_with(
+        "https://api.github.com/user",
+        headers={
+            "Authorization": "Bearer valid-token",
+            "Accept": "application/json",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_validate_github_token_invalid():
+    token = "invalid-token"
+    user_response = Mock()
+    user_response.status = 401
+
+    session = Mock()
+    get_cm = AsyncMock()
+    get_cm.__aenter__.return_value = user_response
+    get_cm.__aexit__.return_value = None
+    session.get.return_value = get_cm
+
+    session_cm = AsyncMock()
+    session_cm.__aenter__.return_value = session
+    session_cm.__aexit__.return_value = None
+
+    with patch("c2casgiutils.auth.aiohttp.ClientSession", return_value=session_cm):
+        login, name = await auth._validate_github_token(token)
+
+    assert login is None
+    assert name is None
+
+
+@pytest.mark.asyncio
+async def test_validate_github_token_network_error():
+    with patch("c2casgiutils.auth.aiohttp.ClientSession", side_effect=aiohttp.ClientError("boom")):
+        login, name = await auth._validate_github_token("token")
+
+    assert login is None
+    assert name is None
+
+
+@pytest.mark.asyncio
+async def test_get_auth_with_bearer_token_success():
+    with patch(
+        "c2casgiutils.auth._validate_github_token", new=AsyncMock(return_value=("testuser", "Test User"))
+    ):
+        request = _request_with_auth_header("valid-token")
+        response = Response()
+        auth_info = await auth.get_auth(request, response)
+
+    assert auth_info.is_logged_in is True
+    assert auth_info.user.login == "testuser"
+    assert auth_info.user.display_name == "Test User"
+    assert auth_info.user.url == "https://github.com/testuser"
+    assert auth_info.user.token == "valid-token"
+
+
+@pytest.mark.asyncio
+async def test_get_auth_with_bearer_token_invalid():
+    with patch("c2casgiutils.auth._validate_github_token", new=AsyncMock(return_value=(None, None))):
+        request = _request_with_auth_header("invalid-token")
+        response = Response()
+        auth_info = await auth.get_auth(request, response)
+
+    assert auth_info.is_logged_in is False
+
+
+@pytest.mark.asyncio
+async def test_get_auth_with_bearer_token_no_github_config():
+    with patch(
+        "c2casgiutils.auth._validate_github_token", new=AsyncMock(return_value=("testuser", "Test User"))
+    ):
+        request = _request_with_auth_header("valid-token")
+        response = Response()
+        auth_info = await auth.get_auth(request, response)
+
+    assert auth_info.is_logged_in is True
+    assert auth_info.user.login == "testuser"
+
+
+@pytest.mark.asyncio
+async def test_check_read_only_access_returns_true_when_not_github_auth():
+    auth_info = auth.AuthInfo(
+        is_logged_in=True,
+        user=auth.UserInfo(login="test", token="token"),
+    )
+
+    has_access = await auth.check_read_only_access(auth_info)
+
+    assert has_access is True
+
+
+@pytest.mark.asyncio
+async def test_check_read_only_access_returns_false_when_not_logged_in():
+    auth_info = auth.AuthInfo(
+        is_logged_in=False,
+        user=auth.UserInfo(),
+    )
+
+    has_access = await auth.check_read_only_access(auth_info)
+
+    assert has_access is False
+
+
+@pytest.mark.asyncio
+async def test_check_read_write_access_returns_true_when_not_github_auth():
+    auth_info = auth.AuthInfo(
+        is_logged_in=True,
+        user=auth.UserInfo(login="test", token="token"),
+    )
+
+    has_access = await auth.check_read_write_access(auth_info)
+
+    assert has_access is True
+
+
+@pytest.mark.asyncio
+async def test_check_read_write_access_returns_false_when_not_logged_in():
+    auth_info = auth.AuthInfo(
+        is_logged_in=False,
+        user=auth.UserInfo(),
+    )
+
+    has_access = await auth.check_read_write_access(auth_info)
+
+    assert has_access is False
+
+
+@pytest.mark.asyncio
+async def test_access_context_require_read_only_access_raises_forbidden():
+    access_context = auth.AccessContext(
+        auth_info=auth.AuthInfo(is_logged_in=False, user=auth.UserInfo()),
+        request=_request(),
+        response=Response(),
+    )
+
+    with pytest.raises(auth.HTTPException) as exception:
+        await access_context.require_read_only_access()
+
+    assert exception.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_access_context_require_read_write_access_raises_forbidden():
+    access_context = auth.AccessContext(
+        auth_info=auth.AuthInfo(is_logged_in=False, user=auth.UserInfo()),
+        request=_request(),
+        response=Response(),
+    )
+
+    with pytest.raises(auth.HTTPException) as exception:
+        await access_context.require_read_write_access()
+
+    assert exception.value.status_code == 403


### PR DESCRIPTION
## Summary
Add support for GitHub Personal Access Token (PAT) authentication via the `Authorization: Bearer` header, and introduce three distinct access levels (read-only, read-write, admin) with separate configurable settings.

## Context
- Allow AI agents and other clients to authenticate programmatically without going through the OAuth web flow
- Replace the single `access_type` setting with three separate levels for finer-grained access control
- The set log level endpoint now requires read-write access, while read-only operations only require read-only access

## Implementation Details
- Added `_validate_github_token()` that validates the token by calling GitHub's `/user` API
- Modified `get_auth()` to check for `Authorization: Bearer <token>` header before falling back to other auth methods
- Split `access_type` into `access_type_read_only` (default: pull), `access_type_read_write` (default: push), and `access_type_admin` (default: admin)
- Access types are now a `GitHubAccessType(StrEnum)` instead of plain strings
- Added `AuthMethod` enum (`github_oauth`, `github_bearer`, `secret`, `test`, `none`) and `type` field to `AuthInfo` to track how the user authenticated
- Added `require_read_only_access`, `require_read_write_access`, `check_read_only_access`, `check_read_write_access` helpers
- `require_admin_access` and `check_admin_access` now properly check the admin access level
- Updated tools routes: GET routes use read-only, POST set log level uses read-write

## Testing & Validation
- All 103 unit tests pass

## Breaking Changes
- Environment variable `C2C__AUTH__GITHUB__ACCESS_TYPE` replaced by `C2C__AUTH__GITHUB__ACCESS_TYPE_READ_ONLY`, `C2C__AUTH__GITHUB__ACCESS_TYPE_READ_WRITE`, and `C2C__AUTH__GITHUB__ACCESS_TYPE_ADMIN`