### PR TITLE
Add StringList, IntList and FloatList type aliases for comma-separated env var parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **StringList type**: Added `StringList` type alias with `BeforeValidator` to parse comma-separated environment variable values into `list[str]`, applied to `Sentry.ignore_errors`, `Sentry.in_app_include`, `Sentry.in_app_exclude`, and `ProxyHeaders.trusted_hosts`.
 - **Async I/O compliance**: Replaced `aiofiles` usage in CLI logging config loading with `anyio.Path`, and removed direct `aiofiles` dependency from project metadata.
 - **GitHub auth sessions**: GitHub OAuth sessions now attempt to refresh expired access tokens automatically. If refresh is unavailable or fails, the auth cookie is cleared so users are logged out instead of remaining logged-in without repository permissions.
 - **Auth dependency ergonomics**: Added injectable `AccessContext` helpers with the methods `require_access`, `require_admin_access`, `check_access` and `check_admin_access` to simplify route protection code.

--- a/c2casgiutils/config.py
+++ b/c2casgiutils/config.py
@@ -70,6 +70,38 @@ class Prometheus(BaseModel):
     port: Annotated[int, Field(description="Port for Prometheus metrics")] = 9000
 
 
+def parse_comma_separated_list(value: str | list[str] | None) -> list[str]:
+    """Parse a comma-separated string into a list of strings."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [v.strip() for v in value if v.strip()]
+    return [v.strip() for v in value.split(",") if v.strip()]
+
+
+def parse_comma_separated_int_list(value: str | list[int] | None) -> list[int]:
+    """Parse a comma-separated string into a list of ints."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [int(v) for v in value]
+    return [int(v.strip()) for v in value.split(",") if v.strip()]
+
+
+def parse_comma_separated_float_list(value: str | list[float] | None) -> list[float]:
+    """Parse a comma-separated string into a list of floats."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [float(v) for v in value]
+    return [float(v.strip()) for v in value.split(",") if v.strip()]
+
+
+StringList = Annotated[list[str], NoDecode, BeforeValidator(parse_comma_separated_list)]
+IntList = Annotated[list[int], NoDecode, BeforeValidator(parse_comma_separated_int_list)]
+FloatList = Annotated[list[float], NoDecode, BeforeValidator(parse_comma_separated_float_list)]
+
+
 class Sentry(BaseModel):
     """
     Sentry configuration.
@@ -83,7 +115,7 @@ class Sentry(BaseModel):
     environment: Annotated[str, Field(description="Sentry environment")] = "production"
     dist: Annotated[str | None, Field(description="Sentry distribution")] = None
     sample_rate: Annotated[float, Field(description="Sample rate for error events")] = 1.0
-    ignore_errors: Annotated[list[str], Field(description="List of exception class names to ignore")] = []
+    ignore_errors: Annotated[StringList, Field(description="List of exception class names to ignore")] = []
     max_breadcrumbs: Annotated[int, Field(description="Maximum number of breadcrumbs to capture")] = 100
     attach_stacktrace: Annotated[bool, Field(description="Attach stack trace to all messages")] = False
     send_default_pii: Annotated[bool | None, Field(description="Send default PII")] = None
@@ -97,11 +129,11 @@ class Sentry(BaseModel):
     server_name: Annotated[str | None, Field(description="Server name for Sentry events")] = None
     project_root: Annotated[str, Field(description="Root directory of the project")] = str(Path.cwd())
     in_app_include: Annotated[
-        list[str],
+        StringList,
         Field(description="List of module prefixes that are in the app"),
     ] = []
     in_app_exclude: Annotated[
-        list[str],
+        StringList,
         Field(description="List of module prefixes that are not in the app"),
     ] = []
     max_request_body_size: Annotated[str, Field(description="Maximum request body size to capture")] = (
@@ -382,7 +414,7 @@ class ProxyHeaders(BaseModel):
         ),
     ] = "none"
     trusted_hosts: Annotated[
-        list[str] | str,
+        StringList,
         Field(
             description=(
                 "Trusted proxy client hosts/networks. Accepts comma-separated string or list "
@@ -390,16 +422,6 @@ class ProxyHeaders(BaseModel):
             ),
         ),
     ] = ["127.0.0.1"]
-
-    @field_validator("trusted_hosts", mode="before")
-    @classmethod
-    def normalize_trusted_hosts(cls, value: list[str] | str | None) -> list[str]:
-        """Normalize trusted_hosts from env values to a list."""
-        if value is None:
-            return ["127.0.0.1"]
-        if isinstance(value, list):
-            return [v.strip() for v in value if v.strip()]
-        return [v.strip() for v in value.split(",") if v.strip()]
 
 
 class Settings(BaseSettings, extra="ignore"):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -3,7 +3,13 @@ import os
 
 import pytest
 
-from c2casgiutils.config import Settings, parse_duration
+from c2casgiutils.config import (
+    Settings,
+    parse_comma_separated_float_list,
+    parse_comma_separated_int_list,
+    parse_comma_separated_list,
+    parse_duration,
+)
 
 
 def test_parse_duration_iso():
@@ -192,3 +198,69 @@ def test_redis_options_from_environment(clean_env):
     settings = Settings()
 
     assert settings.redis.options == {"socket_timeout": 5, "ssl": True}
+
+
+def test_parse_comma_separated_list_none():
+    assert parse_comma_separated_list(None) == []
+
+
+def test_parse_comma_separated_list_list():
+    assert parse_comma_separated_list(["a", "b"]) == ["a", "b"]
+
+
+def test_parse_comma_separated_list_list_with_spaces():
+    assert parse_comma_separated_list([" a ", " b "]) == ["a", "b"]
+
+
+def test_parse_comma_separated_list_empty():
+    assert parse_comma_separated_list("") == []
+
+
+def test_parse_comma_separated_list_single():
+    assert parse_comma_separated_list("value") == ["value"]
+
+
+def test_parse_comma_separated_list_multiple():
+    assert parse_comma_separated_list("a,b,c") == ["a", "b", "c"]
+
+
+def test_parse_comma_separated_list_with_spaces():
+    assert parse_comma_separated_list("a, b, c") == ["a", "b", "c"]
+
+
+def test_sentry_ignore_errors_from_environment(clean_env):
+    os.environ["C2C__SENTRY__IGNORE_ERRORS"] = "ValueError,TypeError,RuntimeError"
+    settings = Settings()
+    assert settings.sentry.ignore_errors == ["ValueError", "TypeError", "RuntimeError"]
+
+
+def test_sentry_in_app_include_from_environment(clean_env):
+    os.environ["C2C__SENTRY__IN_APP_INCLUDE"] = "myapp,myapp2"
+    settings = Settings()
+    assert settings.sentry.in_app_include == ["myapp", "myapp2"]
+
+
+def test_sentry_in_app_exclude_from_environment(clean_env):
+    os.environ["C2C__SENTRY__IN_APP_EXCLUDE"] = "test,test2"
+    settings = Settings()
+    assert settings.sentry.in_app_exclude == ["test", "test2"]
+
+
+def test_proxy_headers_trusted_hosts_from_environment(clean_env):
+    os.environ["C2C__PROXY_HEADERS__TRUSTED_HOSTS"] = "127.0.0.1,10.0.0.0/8, 192.168.1.1"
+    settings = Settings()
+    assert settings.proxy_headers.trusted_hosts == ["127.0.0.1", "10.0.0.0/8", "192.168.1.1"]
+
+
+def test_parse_comma_separated_int_list():
+    assert parse_comma_separated_int_list("1,2,3") == [1, 2, 3]
+    assert parse_comma_separated_int_list("1, 2, 3") == [1, 2, 3]
+    assert parse_comma_separated_int_list(None) == []
+    assert parse_comma_separated_int_list([1, 2, 3]) == [1, 2, 3]
+
+
+def test_parse_comma_separated_float_list():
+    assert parse_comma_separated_float_list("1.5,2.5,3.5") == [1.5, 2.5, 3.5]
+    assert parse_comma_separated_float_list("1.5, 2.5, 3.5") == [1.5, 2.5, 3.5]
+    assert parse_comma_separated_float_list(None) == []
+    assert parse_comma_separated_float_list([1.5, 2.5, 3.5]) == [1.5, 2.5, 3.5]


### PR DESCRIPTION
## Summary
Add `StringList`, `IntList` and `FloatList` type aliases with `BeforeValidator` to parse comma-separated environment variable values into typed lists, replacing manual `field_validator` patterns.

## Implementation Details
- Added `parse_comma_separated_list`, `parse_comma_separated_int_list`, `parse_comma_separated_float_list` functions
- Added `StringList`, `IntList`, `FloatList` type aliases using `NoDecode` + `BeforeValidator`
- Applied `StringList` to `Sentry.ignore_errors`, `Sentry.in_app_include`, `Sentry.in_app_exclude`
- Simplified `ProxyHeaders.trusted_hosts` (removed `list[str] | str` union + `field_validator`)
- `NoDecode` is required to prevent pydantic-settings from trying to parse the value as JSON

## Testing & Validation
- Added unit tests for all three parse functions
- Added tests for Sentry fields and ProxyHeaders.trusted_hosts from environment variables
